### PR TITLE
fix: [utils/sdk/js] bind, resume in Queue

### DIFF
--- a/util/microservice-sdk/js/lib/kafka/ConsumerBackPressure.js
+++ b/util/microservice-sdk/js/lib/kafka/ConsumerBackPressure.js
@@ -104,7 +104,7 @@ module.exports = class ConsumerBackPressure {
 
       // when the processing was finalized, we need to resume the consumer, if
       // it has been paused
-      this.msgQueue.drain(this.resumeConsumer);
+      this.msgQueue.drain(this.resumeConsumer.bind(this));
 
       this.consumer.connect(undefined, (error) => {
         if (error) {
@@ -306,7 +306,7 @@ module.exports = class ConsumerBackPressure {
           nextHoldOffTimeCandidate = nextHoldOffTimeCandidate > this.maxHoldOffTimeSubscription
             ? this.maxHoldOffTimeSubscription : nextHoldOffTimeCandidate;
           nextHoldOffTimeCandidate = nextHoldOffTimeCandidate
-          || this.holdOffTimeSubscription;
+            || this.holdOffTimeSubscription;
           // schedules the next attempt
           setTimeout(subscriptionProcedure, nextHoldOffTimeCandidate, nextHoldOffTimeCandidate);
         }
@@ -427,6 +427,7 @@ module.exports = class ConsumerBackPressure {
    * @access private
    */
   resumeConsumer() {
+    logger.debug(`Calling resume consumer; isPaused? ${this.isPaused}...`, TAG);
     if (this.isPaused) {
       this.consumer.resume(this.consumer.assignments());
       this.isPaused = false;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
When try to resume, this message below appears:

`sdk_1                         | <18:06:00 12/03/2020> -- |undefined -- ERROR: uncaughtException: Cannot read property 'isPaused' of undefined
sdk_1                         | TypeError: Cannot read property 'isPaused' of undefined
sdk_1                         |     at resumeConsumer (/opt/example/lib/kafka/ConsumerBackPressure.js:430:14)
sdk_1                         |     at events.(anonymous function).forEach.handler (/opt/example/node_modules/async/dist/async.js:1254:46)
sdk_1                         |     at Array.forEach (<anonymous>)
sdk_1                         |     at trigger (/opt/example/node_modules/async/dist/async.js:1254:27)
sdk_1                         |     at /opt/example/node_modules/async/dist/async.js:1328:21
sdk_1                         |     at /opt/example/node_modules/async/dist/async.js:326:20
sdk_1                         |     at invokeCallback (/opt/example/node_modules/async/dist/async.js:179:13)
sdk_1                         |     at promise.then.err (/opt/example/node_modules/async/dist/async.js:173:13)
sdk_1                         |     at process._tickCallback (internal/process/next_tick.js:68:7)`

* **What is the new behavior (if this is a feature change)?**
This fix the error

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

#1353 #1401

* **Other information**:
