### PR TITLE
[Fix] to verify the token returned by Redis

### DIFF
--- a/subscription-engine/kafka-ws/app/services/TicketService.js
+++ b/subscription-engine/kafka-ws/app/services/TicketService.js
@@ -32,7 +32,7 @@ function generateTicket(token) {
 }
 
 /**
- * Verify the integrity and authenticity of the token.
+ * Verifies the integrity and authenticity of the token.
  *
  * @param {String} token Token to verify
  * @param {String} ticket Ticket received

--- a/subscription-engine/kafka-ws/app/services/TicketService.js
+++ b/subscription-engine/kafka-ws/app/services/TicketService.js
@@ -34,9 +34,9 @@ function generateTicket(token) {
 /**
  * Verify the integrity and authenticity of the token.
  *
- * @param {*} token Token to verify
- * @param {*} ticket ticket received
- * @returns {Boolean} if the token is authentic, the ticket received
+ * @param {String} token Token to verify
+ * @param {String} ticket Ticket received
+ * @returns {Boolean} If the token is authentic, the ticket received
  *                    and the computed ticket will match.
  */
 function verifyToken(token, ticket) {

--- a/subscription-engine/kafka-ws/package.json
+++ b/subscription-engine/kafka-ws/package.json
@@ -82,7 +82,9 @@
     "testMatch": [
       "**/test/**/**.test.js"
     ],
-    "setupFilesAfterEnv": ["./jest.setup.js"]
+    "setupFilesAfterEnv": [
+      "./jest.setup.js"
+    ]
   },
   "author": "@eduardogmisiuk",
   "contributors": [


### PR DESCRIPTION
Fix to recalculate the HMAC token returned by redis to ascertain the integrity and authenticity of the token.
if the token is authentic, the ticket received and the computed ticket will match.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It adds a layer of security when checking the token that was stored in Redis. In this way, we guarantee that no other service has violated the token.

* **What is the current behavior?** (You can also link to an open issue here)

Until then, this verification was not performed

* **What is the new behavior (if this is a feature change)?**

When the service receives the token back, your HMAC is recalculated

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

-