### PR TITLE
[fix] Endpoint change to facilitate API Gateway redirection

### DIFF
--- a/subscription-engine/kafka-ws/README.md
+++ b/subscription-engine/kafka-ws/README.md
@@ -15,7 +15,7 @@ The connection is done in two steps, you must first obtain a *single-use ticket*
 #### First step: Get the single-use ticket
 
 A ticket allows the user to subscribe to a dojot topic. To obtain it is necessary to have a JWT access token that is issued by the platform's Authentication/Authorization service.
-Ticket request must be made by REST at the endpoint `/api/v1/ticket` using the HTTP GET verb. The request must contain the header `Authorization` and the JWT token as value, according to the syntax:
+Ticket request must be made by REST at the endpoint `<base-url>/kafka-ws/v1/ticket` using the HTTP GET verb. The request must contain the header `Authorization` and the JWT token as value, according to the syntax:
 
     POST <base-url>/v1/ticket
     Authorization: Bearer [Encoded JWT]
@@ -32,10 +32,9 @@ Note: In the context of a dojot deployment the JWT Token is provided by the *Aut
 
 #### Second step: Establish a websocket connection
 
-The connection is done via pure websockets using the URI `/api/v1/topics/:topic`. You **must** pass the previously generated ticket as a parameter of this URI. It is also possible to pass conditional and filter options as parameters of the URI.
+The connection is done via pure websockets using the URI `<base-url>/kafka-ws/v1/topics/:topic`. You **must** pass the previously generated ticket as a parameter of this URI. It is also possible to pass conditional and filter options as parameters of the URI.
 
 In the following sections, it is explained in details how to compose the URI to retrieve filtered and/or partial data from a given topic.<br>
-*Note*: When the component is behind the API Gateway of the dojot platform, it must be accessed through the URI: `<base-url>/kafka-ws/v1/topics/:topic`.
 
 If you want to jump for a full client example, see the [examples](./examples) directory.
 
@@ -44,7 +43,7 @@ If you want to jump for a full client example, see the [examples](./examples) di
 Before diving into the explanation of how each filter works and its rules, it is necessary to understand the parts of the URI. It's general format is:
 
 ```
-/api/v1/topics/:topic?ticket=<hexValue>&fields=<selector>&where=<conditions>
+/kafka-ws/v1/topics/:topic?ticket=<hexValue>&fields=<selector>&where=<conditions>
 ```
 
 #### Topic
@@ -90,31 +89,31 @@ To ilustrate the parameters' usage, here are some examples of valid URIs:
 Retrieving full messages from `topic.example` topic:
 
 ```
-/api/v1/topics/topic.example
+/kafka-ws/v1/topics/topic.example
 ```
 
 Retrieving a sensor *status* and *temperature* when the *status* is `failed` or `stopped`:
 
 ```
-/api/v1/topics/topic.example?fields=sensor/status,temperature&where=sensor.status=in:failed,stopped;
+/kafka-ws/v1/topics/topic.example?fields=sensor/status,temperature&where=sensor.status=in:failed,stopped;
 ```
 
 Retrieving the *temperature* and *location*:
 
 ```
-/api/v1/topics/topic.example?fields=temperature,location
+/kafka-ws/v1/topics/topic.example?fields=temperature,location
 ```
 
 Retrieving full messages where *temperature* is <ins>greater than or equal to</ins> 5.0 and <ins>less than</ins> 10.0:
 
 ```
-/api/v1/topics/topic.example?where=temperature=gte:5.0;temperature=lt:10.0;
+/kafka-ws/v1/topics/topic.example?where=temperature=gte:5.0;temperature=lt:10.0;
 ```
 
 Retrieving the *temperature* and *rain* where *rain* is <ins>less than or equal to</ins> 15:
 
 ```
-/api/v1/topics/topic.example?where=rain=lte:15;&fields=temperature,rain
+/kafka-ws/v1/topics/topic.example?where=rain=lte:15;&fields=temperature,rain
 ```
 
 ### **Filtering flow**

--- a/subscription-engine/kafka-ws/app/App.js
+++ b/subscription-engine/kafka-ws/app/App.js
@@ -42,7 +42,7 @@ function configure(server) {
   /* Open API - Routes available through the API Gateway
    * First the request goes through the ticket router,
    * then it goes through the topic router. */
-  app.use('/api/v1',
+  app.use('/kafka-ws/v1',
     accessControlRouter(),
     ticketRouter(),
     topicsRouter());

--- a/subscription-engine/kafka-ws/docs/apiary.apib
+++ b/subscription-engine/kafka-ws/docs/apiary.apib
@@ -10,7 +10,7 @@ from Kafka.
 
 A ticket allows the user to subscribe to a dojot topic. To obtain it is necessary to have a JWT access token that is issued by the platform's Authentication/Authorization service.
 
-## Getting a ticket [/api/v1/ticket]
+## Getting a ticket [/kafka-ws/v1/ticket]
 
 ### A single-use Ticket [GET]
 
@@ -37,7 +37,7 @@ Gets a single-use Ticket. It can only be used once and has a very short validity
 in a Kafka cluster. It works with pure websocket connections, so you can create clients in any
 language you want, as long as the client supports **RFC 6455** websockets.
 
-## Retrieving conditional and/or partial messages from topic: [/api/v1/topics/{topic}?ticket={ticket}&fields={selector}&where={conditions}]
+## Retrieving conditional and/or partial messages from topic: [/kafka-ws/v1/topics/{topic}?ticket={ticket}&fields={selector}&where={conditions}]
 
 ### **Where**
 
@@ -65,27 +65,27 @@ To ilustrate the parameters' usage, here are some examples of valid URIs:
 
 Retrieving full messages from `topic.example` topic:
 ```
-/api/v1/topics/topic.example
+/kafka-ws/v1/topics/topic.example
 ```
 
 Retrieving a sensor status and temperature when the status is `failed` or `stopped`:
 ```
-/api/v1/topics/topic.example?fields=sensor/status,temperature&where=sensor.status=in:failed,stopped;
+/kafka-ws/v1/topics/topic.example?fields=sensor/status,temperature&where=sensor.status=in:failed,stopped;
 ```
 
 Retrieving the temperature and location:
 ```
-/api/v1/topics/topic.example?fields=temperature,location
+/kafka-ws/v1/topics/topic.example?fields=temperature,location
 ```
 
 Retrieving full messages where 5.0 ≤ temperature < 10.0:
 ```
-/api/v1/topics/topic.example?where=temperature=lt:10.0;temperature=gte:5.0;
+/kafka-ws/v1/topics/topic.example?where=temperature=lt:10.0;temperature=gte:5.0;
 ```
 
 Retrieving the temperature and rain when rain ≤ 15:
 ```
-/api/v1/topics/topic.example?where=rain=lte:15;&fields=temperature,rain
+/kafka-ws/v1/topics/topic.example?where=rain=lte:15;&fields=temperature,rain
 ```
 
 ---

--- a/subscription-engine/kafka-ws/examples/WSClient/Client.js
+++ b/subscription-engine/kafka-ws/examples/WSClient/Client.js
@@ -45,7 +45,7 @@ async function generateAccessToken(tenant) {
 async function requestTicket(accessToken) {
   console.info('Requesting a ticket needed to open a websocket communication...');
   const protocol = (tls) ? 'https' : 'http';
-  const uri = `${protocol}://${host}:${port}/api/v1/ticket`;
+  const uri = `${protocol}://${host}:${port}/kafka-ws/v1/ticket`;
   const agent = (tls)
     ? superagent.get(uri).ca(ca).key(key).cert(cert)
     : superagent.get(uri);
@@ -60,7 +60,7 @@ async function requestTicket(accessToken) {
 function generateWebsocketURI(option, ticket) {
   console.info('Generating the websocket connection URI...');
   const protocol = (tls) ? 'wss' : 'ws';
-  const endpoint = `${protocol}://${host}:${port}/api/v1/topics`;
+  const endpoint = `${protocol}://${host}:${port}/kafka-ws/v1/topics`;
   let resource;
   const queryParams = [];
   if (option === '0') {

--- a/subscription-engine/kafka-ws/test/integration/AccessControl.test.js
+++ b/subscription-engine/kafka-ws/test/integration/AccessControl.test.js
@@ -50,7 +50,7 @@ const req = request(server);
 
 describe('Integration tests related to websocket access control', () => {
   it('should be unauthorized because of a missing ticket',
-    () => req.get('/api/v1/topics/dummy.topic')
+    () => req.get('/kafka-ws/v1/topics/dummy.topic')
       .send()
       .expect(401)
       .then((res) => {
@@ -58,7 +58,7 @@ describe('Integration tests related to websocket access control', () => {
       }));
 
   it('should be unauthorized because of a invalid ticket',
-    () => req.get('/api/v1/topics/dummy.topic?ticket=fake')
+    () => req.get('/kafka-ws/v1/topics/dummy.topic?ticket=fake')
       .send()
       .expect(401)
       .then((res) => {
@@ -75,7 +75,7 @@ describe('Integration tests related to websocket access control', () => {
         cfg.app.ticket.secret,
         { expiresIn: 60 },
       ).then((token) => new Promise(((resolve, reject) => {
-        req.get('/api/v1/ticket')
+        req.get('/kafka-ws/v1/ticket')
           .set('Authorization', `Bearer ${token}`)
           .send()
           .expect(200)
@@ -93,7 +93,7 @@ describe('Integration tests related to websocket access control', () => {
       (done) => {
         server.listen(0);
         const { port } = server.address();
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/api/v1/topics/${tenant}.topic?ticket=${ticket}`);
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/kafka-ws/v1/topics/${tenant}.topic?ticket=${ticket}`);
 
         ws.on('close', () => {
           expect(WebsocketTarball.onConnection).toHaveBeenCalled();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR changes the main endpoint of the kafka-ws component, this is necessary to facilitate redirection through the API Gateway

* **What is the current behavior?** (You can also link to an open issue here)

The main endpoint of the component starts with `/api/**`

* **What is the new behavior (if this is a feature change)?**

The main endpoint of the component will start with `/kafka-ws/**`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This change also affects the API Gateway configuration, but client applications will not change.

* **Other information**:

This makes it easier to configure the API Gateway on the component's sub-routes