### PR TITLE
Feature: sdk logger with default console transport

### DIFF
--- a/util/microservice-sdk/js/README.md
+++ b/util/microservice-sdk/js/README.md
@@ -58,7 +58,7 @@ Where:
 The transports ('console' and 'file') are shared by all instances of the wrapper. So,
 any change in the transports will affect all instances.
 
-By default, no transport is set, so it is necessary to do this as part of the configuration
+By default, console transport is set, but this can be changed as part of the configuration
 or initialization of the microservice.
 
 It's usage is very simple and is shown by the following example:
@@ -66,13 +66,13 @@ It's usage is very simple and is shown by the following example:
 ```js
 const { Logger } = require('@dojot/microservice-sdk');
 
-// By default, no transport is enabled; so you need to
-// set at least one before to log the messages.
+// By default, console transport is enabled; but you can
+// change it or add a file transport if required.
 // It's worth to say that the transports are shared by all
 // modules of the microservice; consequently, any change
 // in the configuration will be valid for all!
 
-// Setting console transport
+// Setting console transport (this will replace the console set by default)
 // For more information about it, see:
 // https://github.com/winstonjs/winston/blob/HEAD/docs/transports.md#console-transport
 //

--- a/util/microservice-sdk/js/examples/consumer/sample.js
+++ b/util/microservice-sdk/js/examples/consumer/sample.js
@@ -1,8 +1,8 @@
 const { Logger, Kafka: { Consumer } } = require('../index.js');
 
 // Set the global logger properties
-// Add a console transport
-Logger.setTransport('console', { level: 'debug' });
+// Console transport is set by default, but with info level
+Logger.setLevel('console', 'debug');
 
 // Enable verbose mode
 Logger.setVerbose(true);

--- a/util/microservice-sdk/js/examples/logging/index.js
+++ b/util/microservice-sdk/js/examples/logging/index.js
@@ -1,13 +1,13 @@
 const { Logger } = require('@dojot/microservice-sdk');
 const { logSampleMessages } = require('./SampleModule');
 
-// By default, no transport is enabled; so you need to
-// set at least one before to log the messages.
+// By default, console transport is enabled; but you can
+// change it or add a file transport if required.
 // It's worth to say that the transports are shared by all
 // modules of the microservice; consequently, any change
 // in the configuration will be valid for all!
 
-// Setting console transport
+// Setting console transport (this will replace the console set by default)
 // For more information about it, see:
 // https://github.com/winstonjs/winston/blob/HEAD/docs/transports.md#console-transport
 //

--- a/util/microservice-sdk/js/examples/producer/sample.js
+++ b/util/microservice-sdk/js/examples/producer/sample.js
@@ -3,8 +3,8 @@ const util = require('util');
 const { Logger, Kafka: { Producer } } = require('../index.js');
 
 // Set the global logger properties
-// Add a console transport
-Logger.setTransport('console', { level: 'debug' });
+// Console transport is set by default, but with info level
+Logger.setLevel('console', 'debug');
 
 // Enable verbose mode
 Logger.setVerbose(true);

--- a/util/microservice-sdk/js/lib/logging/Logger.js
+++ b/util/microservice-sdk/js/lib/logging/Logger.js
@@ -93,6 +93,7 @@ class Logger {
 
   /**
    * Sets the transport.
+   * If the transport has already been set, it replaces the old one.
    * Note that this method is static, so it sets the 'global' logger.
    *
    * @param { string } transport  name of the transport. It can be:
@@ -109,9 +110,9 @@ class Logger {
       throw new Error('The config must be an object value.');
     }
 
-    // validate current state
+    // remove the corresponding transport if has set
     if (this.isTransportSet(transport)) {
-      throw new Error('Transport has been set. It is necessary to unset it.');
+      Logger.unsetTransport(transport);
     }
 
     // create the new  transport
@@ -236,5 +237,8 @@ Logger.sharedLogger = {
   handleMetadata: (metadata) => (Logger.sharedLogger.verbose
     ? addFileAndLineToMetadata(metadata) : metadata),
 };
+
+// Enable console transport by default
+Logger.setTransport('console');
 
 module.exports = { Logger };

--- a/util/microservice-sdk/js/test/unit/logging/Logger.test.js
+++ b/util/microservice-sdk/js/test/unit/logging/Logger.test.js
@@ -58,7 +58,7 @@ const { createWinstonTransport } = require('../../../lib/logging/Transports');
 // setup - console is set by default
 beforeEach(() => {
   Logger.sharedLogger.transports = {
-    console: createWinstonTransport('console', {level: 'info'}),
+    console: createWinstonTransport('console', { level: 'info' }),
     file: null,
   };
   Logger.sharedLogger.wlogger.transports = {
@@ -70,6 +70,7 @@ beforeEach(() => {
 
 // logger configuration tests
 // static methods
+describe('Logger configuration', () => {
   test('Set a valid transport - file', () => {
     // file transport is unset
     expect(Logger.isTransportSet('file')).toBeFalsy();
@@ -155,13 +156,13 @@ beforeEach(() => {
     Logger.setTransport('console', { level: 'debug' });
     expect(winston.transports.Console).toBeCalledWith(
       expect.objectContaining({
-        level: 'debug'
+        level: 'debug',
       }),
     );
     Logger.setTransport('file', { level: 'debug' });
     expect(winston.transports.DailyRotateFile).toBeCalledWith(
       expect.objectContaining({
-        level: 'debug'
+        level: 'debug',
       }),
     );
   });
@@ -337,6 +338,7 @@ beforeEach(() => {
       Logger.setVerbose('true');
     }).toThrow('The parameter enable must be a boolean.');
   });
+});
 
 describe('Logger wrapper instantiation', () => {
   test('Instantiate a logger wrapper - sucess', () => {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


* **What is the current behavior?** (You can also link to an open issue here)
The logger of the SDK library doesn't set any transport as default, and if the user forgets to set it, the logging messages are printed out in an unexpected format. 

* **What is the new behavior (if this is a feature change)?**
Now the console transport is enabled by default with 'info' logging level. This configuration is used by most of the dojot microservices; so they don't need to worry to set it anymore. Also, the behavior of the method 'setTransport' changed to replace existing configurations. This way, existing code will continue to work.

This commit didn't change the SDK version, this should be done when
a new version of the SDK library is released.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Users don't need to change their codes.

* **Other information**:
