### PR TITLE
Feature: sdk logger with default console transport (#1537)

### DIFF
--- a/util/microservice-sdk/js/README.md
+++ b/util/microservice-sdk/js/README.md
@@ -58,7 +58,7 @@ Where:
 The transports ('console' and 'file') are shared by all instances of the wrapper. So,
 any change in the transports will affect all instances.
 
-By default, no transport is set, so it is necessary to do this as part of the configuration
+By default, console transport is set, but this can be changed as part of the configuration
 or initialization of the microservice.
 
 It's usage is very simple and is shown by the following example:
@@ -66,13 +66,13 @@ It's usage is very simple and is shown by the following example:
 ```js
 const { Logger } = require('@dojot/microservice-sdk');
 
-// By default, no transport is enabled; so you need to
-// set at least one before to log the messages.
+// By default, console transport is enabled; but you can
+// change it or add a file transport if required.
 // It's worth to say that the transports are shared by all
 // modules of the microservice; consequently, any change
 // in the configuration will be valid for all!
 
-// Setting console transport
+// Setting console transport (this will replace the console set by default)
 // For more information about it, see:
 // https://github.com/winstonjs/winston/blob/HEAD/docs/transports.md#console-transport
 //

--- a/util/microservice-sdk/js/examples/consumer/sample.js
+++ b/util/microservice-sdk/js/examples/consumer/sample.js
@@ -1,8 +1,8 @@
 const { Logger, Kafka: { Consumer } } = require('../index.js');
 
 // Set the global logger properties
-// Add a console transport
-Logger.setTransport('console', { level: 'debug' });
+// Console transport is set by default, but with info level
+Logger.setLevel('console', 'debug');
 
 // Enable verbose mode
 Logger.setVerbose(true);

--- a/util/microservice-sdk/js/examples/logging/index.js
+++ b/util/microservice-sdk/js/examples/logging/index.js
@@ -1,13 +1,13 @@
 const { Logger } = require('@dojot/microservice-sdk');
 const { logSampleMessages } = require('./SampleModule');
 
-// By default, no transport is enabled; so you need to
-// set at least one before to log the messages.
+// By default, console transport is enabled; but you can
+// change it or add a file transport if required.
 // It's worth to say that the transports are shared by all
 // modules of the microservice; consequently, any change
 // in the configuration will be valid for all!
 
-// Setting console transport
+// Setting console transport (this will replace the console set by default)
 // For more information about it, see:
 // https://github.com/winstonjs/winston/blob/HEAD/docs/transports.md#console-transport
 //

--- a/util/microservice-sdk/js/examples/producer/sample.js
+++ b/util/microservice-sdk/js/examples/producer/sample.js
@@ -3,8 +3,8 @@ const util = require('util');
 const { Logger, Kafka: { Producer } } = require('../index.js');
 
 // Set the global logger properties
-// Add a console transport
-Logger.setTransport('console', { level: 'debug' });
+// Console transport is set by default, but with info level
+Logger.setLevel('console', 'debug');
 
 // Enable verbose mode
 Logger.setVerbose(true);

--- a/util/microservice-sdk/js/lib/logging/Logger.js
+++ b/util/microservice-sdk/js/lib/logging/Logger.js
@@ -93,6 +93,7 @@ class Logger {
 
   /**
    * Sets the transport.
+   * If the transport has already been set, it replaces the old one.
    * Note that this method is static, so it sets the 'global' logger.
    *
    * @param { string } transport  name of the transport. It can be:
@@ -109,9 +110,9 @@ class Logger {
       throw new Error('The config must be an object value.');
     }
 
-    // validate current state
+    // remove the corresponding transport if has set
     if (this.isTransportSet(transport)) {
-      throw new Error('Transport has been set. It is necessary to unset it.');
+      Logger.unsetTransport(transport);
     }
 
     // create the new  transport
@@ -236,5 +237,8 @@ Logger.sharedLogger = {
   handleMetadata: (metadata) => (Logger.sharedLogger.verbose
     ? addFileAndLineToMetadata(metadata) : metadata),
 };
+
+// Enable console transport by default
+Logger.setTransport('console');
 
 module.exports = { Logger };

--- a/util/microservice-sdk/js/test/unit/logging/Logger.test.js
+++ b/util/microservice-sdk/js/test/unit/logging/Logger.test.js
@@ -52,17 +52,17 @@ jest.mock('winston-daily-rotate-file');
 const winston = require('winston');
 
 const { Logger } = require('../../../lib/logging/Logger');
-const { textFormat, jsonFormat } = require('../../../lib/logging/Formats');
+const { jsonFormat } = require('../../../lib/logging/Formats');
+const { createWinstonTransport } = require('../../../lib/logging/Transports');
 
-// setup
-// teardown
-afterEach(() => {
+// setup - console is set by default
+beforeEach(() => {
   Logger.sharedLogger.transports = {
-    console: null,
+    console: createWinstonTransport('console', { level: 'info' }),
     file: null,
   };
   Logger.sharedLogger.wlogger.transports = {
-    console: { level: null },
+    console: { level: 'info' },
     file: { level: null },
   };
   jest.clearAllMocks();
@@ -71,25 +71,6 @@ afterEach(() => {
 // logger configuration tests
 // static methods
 describe('Logger configuration', () => {
-  test('Set a valid transport - console', () => {
-    // console transport is unset
-    expect(Logger.isTransportSet('console')).toBeFalsy();
-
-    // set console transport
-    Logger.setTransport('console', { level: 'error' });
-
-    // expected ...
-    expect(winston.transports.Console.mock.calls.length).toBe(1);
-    expect(winston.transports.Console).toBeCalledWith(
-      expect.objectContaining({
-        level: 'error',
-        format: textFormat,
-      }),
-    );
-    expect(Logger.sharedLogger.wlogger.add.mock.calls.length).toBe(1);
-    expect(Logger.isTransportSet('console')).toBeTruthy();
-  });
-
   test('Set a valid transport - file', () => {
     // file transport is unset
     expect(Logger.isTransportSet('file')).toBeFalsy();
@@ -111,7 +92,7 @@ describe('Logger configuration', () => {
 
   test('Unset valid transports', () => {
     // set transports
-    Logger.setTransport('console', { level: 'error' });
+    // console set by default
     Logger.setTransport('file', { level: 'error' });
 
     // intermediate checks
@@ -162,24 +143,28 @@ describe('Logger configuration', () => {
     }).toThrow('The config must be an object value.');
   });
 
-  test('Trying to set a transport that has been set', () => {
+  test('Replacing a transport that has been set', () => {
     // set transports
-    Logger.setTransport('console', { level: 'error' });
+    // console set by default
     Logger.setTransport('file', { level: 'error' });
 
     // intermediate check
     expect(Logger.isTransportSet('console')).toBeTruthy();
     expect(Logger.isTransportSet('file')).toBeTruthy();
 
-    // console has been set
-    expect(() => {
-      Logger.setTransport('console');
-    }).toThrow('Transport has been set. It is necessary to unset it.');
-
-    // console has been set
-    expect(() => {
-      Logger.setTransport('file');
-    }).toThrow('Transport has been set. It is necessary to unset it.');
+    // replacing
+    Logger.setTransport('console', { level: 'debug' });
+    expect(winston.transports.Console).toBeCalledWith(
+      expect.objectContaining({
+        level: 'debug',
+      }),
+    );
+    Logger.setTransport('file', { level: 'debug' });
+    expect(winston.transports.DailyRotateFile).toBeCalledWith(
+      expect.objectContaining({
+        level: 'debug',
+      }),
+    );
   });
 
   test('Unset transport with invalid parameter - transport name', () => {
@@ -205,8 +190,7 @@ describe('Logger configuration', () => {
   });
 
   test('Set a valid logging level - console', () => {
-    // set console transport
-    Logger.setTransport('console', { level: 'error' });
+    // console set by default
 
     // change console level to debug
     Logger.setLevel('console', 'debug');
@@ -302,6 +286,9 @@ describe('Logger configuration', () => {
   });
 
   test('Trying to set logging level for an unset transport', () => {
+    // uset console
+    Logger.unsetTransport('console');
+
     // console
     expect(() => {
       Logger.setLevel('console', 'error');


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ X ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
The user is forced to set a logging transport when the SDK is used; otherwise, messages are logged in an unexpected format.


* **What is the new behavior (if this is a feature change)?**
Now the console transport is enabled by default with 'info'
logging level. This configuration is used by most of the
dojot microservices; so they don't need to worry to set it
anymore. Also, the behavior of the method 'setTransport' changed
to replace existing configurations. This way, existing code will
continue to work.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

There is no breaking changes. 

* **Other information**:

This commit didn't change the SDK version, this should be done when
a new version of the SDK library is released.
