### PR TITLE
[fix] Fixes Locust problems with revoke, renew and gevent version

### DIFF
--- a/connector/mqtt/locust/Docker/docker-compose-master.yml
+++ b/connector/mqtt/locust/Docker/docker-compose-master.yml
@@ -2,27 +2,22 @@ version: '3'
 services:
   locust-master:
     image: dojot/locust:development
+    command: bash master_entrypoint.sh
+    volumes:
+      - ..:/usr/src/app
+    environment:
+      DOJOT_URL: "http://127.0.0.1:8000"
+      DOJOT_MQTT_HOST: "127.0.0.1"
+      # TODO: differentiate DOJOT_MQTT_PORT and DOJOT_MQTTS_PORT variables
+      DOJOT_MQTT_PORT: "1883"
+      DOJOT_MQTT_TIMEOUT: "120"
+      REDIS_PASSWD: ""
+      REDIS_BACKUP: "y"
+      DOJOT_ENV: "n"
     networks:
       - default
     depends_on:
       - redis
-    environment:
-      # Don't forget to set the environment variables
-      DOJOT_URL: "http://10.202.12.47:30001"
-      DOJOT_USER: "admin"
-      DOJOT_PASSWD: "admin"
-      DOJOT_MQTT_HOST: "10.202.12.47"
-      # TODO: differentiate DOJOT_MQTT_PORT and DOJOT_MQTTS_PORT variables
-      DOJOT_MQTT_PORT: "30311"
-      DOJOT_MQTT_TIMEOUT: "120"
-      REDIS_HOST: "redis"
-      REDIS_PORT: "6379"
-      REDIS_PASSWD: ""
-      REDIS_BACKUP: "y"
-      DOJOT_ENV: "y"
-    command: bash master_entrypoint.sh
-    volumes:
-      - ..:/usr/src/app
     ports:
       - 8089:8089
       - 5557:5557

--- a/connector/mqtt/locust/Docker/docker-compose-slave.yml
+++ b/connector/mqtt/locust/Docker/docker-compose-slave.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ..:/usr/src/app
     environment:
-      # Don't forget to set the environment variables
+      DOJOT_URL: "http://127.0.0.1:8000"
       DOJOT_MQTT_HOST: "127.0.0.1"
       # TODO: differentiate DOJOT_MQTT_PORT and DOJOT_MQTTS_PORT variables
       DOJOT_MQTT_PORT: "1883"
@@ -17,6 +17,7 @@ services:
       REDIS_PASSWD: ""
       TASK_MIN_TIME: "29500"
       TASK_MAX_TIME: "30000"
+      EJBCA_URL: "http://localhost:5583"
       LOG_LEVEL: "info"
 
       RENEW_DEVICES: "False"

--- a/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       - ../../..:/usr/src/app
     environment:
       DOJOT_URL: "http://127.0.0.1:8000"
-      DOJOT_USER: "admin"
-      DOJOT_PASSWD: "admin"
       DOJOT_MQTT_HOST: "127.0.0.1"
       DOJOT_MQTT_PORT: "1883"
       DOJOT_ENV: "n"
+
+      EJBCA_URL: "http://localhost:5583"
 
       REDIS_HOST: "redis"
       REDIS_PORT: "6379"

--- a/connector/mqtt/locust/requirements/prod.txt
+++ b/connector/mqtt/locust/requirements/prod.txt
@@ -2,3 +2,4 @@ locustio==0.12.2
 redis==3.3.7
 paho-mqtt==1.4.0
 pyopenssl==19.1.0
+gevent==1.4.0

--- a/connector/mqtt/locust/src/ejbca/cert_utils.py
+++ b/connector/mqtt/locust/src/ejbca/cert_utils.py
@@ -85,7 +85,7 @@ class CertUtils:
         """
         Verifies whether the certificate has been revoked or not.
         """
-        url = CONFIG["dojot"]["url"]+ "x509/v1/certificates/" + thing.cert.crt['fingerprint']
+        url = CONFIG["dojot"]["url"]+ "/x509/v1/certificates/" + thing.cert.crt['fingerprint']
 
         res = requests.get(
             url=url,

--- a/connector/mqtt/locust/src/ejbca/certificate.py
+++ b/connector/mqtt/locust/src/ejbca/certificate.py
@@ -15,7 +15,6 @@ class Certificate:
 
     def __init__(self, device_id):
         self.logger = Utils.create_logger("certificate")
-        # Utils.validate_thing_id(thing_id)
 
         self.jwt = RedisClient().get_jwt()
 
@@ -68,8 +67,6 @@ class Certificate:
         """
         Renew a certificate.
         """
-        self.revoke_cert()
-
         self.key = {"pem": self.generate_private_key()}
         self.csr = {"pem": self.generate_csr()}
         self.crt = {}

--- a/connector/mqtt/locust/tests/ejbca/test_certificate.py
+++ b/connector/mqtt/locust/tests/ejbca/test_certificate.py
@@ -88,8 +88,10 @@ class TestCertificate(unittest.TestCase):
         thing = Certificate(self.thing_id)
         thing.renew_cert()
 
-        mock_api.revoke_certificate.assert_called_once_with(self.jwt, self.crt['fingerprint'])
         self.assertIsNotNone(thing.crt['pem'])
+        self.assertIsNotNone(thing.crt['fingerprint'])
+        self.assertIsNotNone(thing.csr['pem'])
+        self.assertIsNotNone(thing.key['pem'])
 
     def test_revoke(self, _mock_crypto, _mock_utils, mock_redis, mock_api):
         """

--- a/connector/mqtt/locust/tests/mqtt_locust/test_mqtt_client.py
+++ b/connector/mqtt/locust/tests/mqtt_locust/test_mqtt_client.py
@@ -639,7 +639,7 @@ class MQTTClientRevokeCertAndEmitEvent(unittest.TestCase):
         """
         client = MQTTClient("123", "987", True, False)
 
-        mock_cert_utils.has_been_revoked.return_value = True
+        mock_cert_utils.has_been_revoked.return_value = False
 
         has_revoked = client.revoke_cert_and_emit_event()
 
@@ -650,31 +650,18 @@ class MQTTClientRevokeCertAndEmitEvent(unittest.TestCase):
 
     def test_not_revoke_cert_and_emit_event(self, mock_utils, _mock_paho, mock_cert_utils):
         """
-        Should not revoke cert
+        Should not revoke cert - Exception thrown by the revoking function
         """
         client = MQTTClient("123", "987", True, False)
 
         mock_cert_utils.has_been_revoked.return_value = False
+        mock_cert_utils.revoke_cert.side_effect = Exception
 
         has_revoked = client.revoke_cert_and_emit_event()
 
         self.assertFalse(has_revoked)
         mock_cert_utils.revoke_cert.assert_called_once()
         mock_utils.fire_locust_failure.assert_called()
-
-
-    def test_revoke_cert_and_emit_event_exception(self, mock_utils, _mock_paho, mock_cert_utils):
-        """
-        Revoking should throw an exception.
-        """
-        mock_cert_utils.revoke_cert.side_effect = Exception
-        client = MQTTClient("123", "987", True, False)
-
-        res = client.revoke_cert_and_emit_event()
-
-        self.assertRaises(Exception, mock_cert_utils.revoke_cert)
-        mock_utils.fire_locust_failure.assert_called()
-        self.assertFalse(res)
 
 
 @patch('src.mqtt_locust.mqtt_client.json')


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
1. Locust throws an error when initializing
2. Revoke is not working
3. Renew is not working

* **What is the new behavior (if this is a feature change)?**
1. Locust does not throw an error when initializing, the problem is gevent version is not fixed in Locust 0.12.2 (it is fixed in later versions)
2. Revoke is working - missing slash in the URL was preventing it from working
3. Renew is working - it was trying to revoke twice, so the second call to EJBCA was returning 404, thus failing

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
