### PR TITLE
[fix] Missing comma in VerneMQ Dockerfile entrypoint arguments

### DIFF
--- a/connector/mqtt/vernemq/broker/Dockerfile
+++ b/connector/mqtt/vernemq/broker/Dockerfile
@@ -45,6 +45,6 @@ RUN mkdir -p /vernemq/cert/ && \
 COPY bin/command.sh /
 
 RUN apk add --no-cache tini
-ENTRYPOINT ["/sbin/tini" "--"]
+ENTRYPOINT ["/sbin/tini", "--"]
 
 USER vernemq


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.

* **What is the current behavior?** (You can also link to an open issue here)
VerneMQ Dockerfile entrypoint arguments are not being separated by commas.

* **What is the new behavior (if this is a feature change)?**
Add comma.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
