### PR TITLE
Changing the location of the profiles directory

### DIFF
--- a/x509-identity-mgmt/Dockerfile
+++ b/x509-identity-mgmt/Dockerfile
@@ -36,7 +36,7 @@ RUN npm install --unsafe-perm --production
 COPY --chown=10001:0 js /opt/x509-identity-mgmt
 
 # Copy EJBCA profiles
-COPY --chown=10001:0 ejbca/resources/profiles/ /mnt/persistent/profiles/
+COPY --chown=10001:0 ejbca/resources/profiles/ /opt/primekey/profiles/
 
 # Copy EJBCA setup scripts
 COPY --chown=10001:0 ejbca/bin/ /opt/primekey/bin/internal/

--- a/x509-identity-mgmt/ejbca/README.md
+++ b/x509-identity-mgmt/ejbca/README.md
@@ -66,7 +66,6 @@ The access to EJBCA's functionalities is done through the certificate that it is
 
 | Variable | Description |
 |----------|-------------|
-| EJBCA_PROFILES_DIR | The directory where are located the XML files that define EJBCA's Certificate and End Entities Profiles. <br>**Default**: /mnt/persistent/profiles <br><br> Note 1: Profile xml files are generated and edited through the web administration panel offered by the EJBCA server. <br><br>Note 2: The name of the profiles must not contain spaces. |
 | **Certificate Profiles** | |
 | EJBCA_DEVICES_CA_CERT_PROFILE | Name of the certificate profile of the root CA used to sign certificates for IoT devices. <br>**Default**: X509IdentitiesCA |
 | EJBCA_SERVICES_CA_CERT_PROFILE | Name of the certificate profile of the root CA used to sign certificates for dojot services. <br>**Default**: ServicesCA |

--- a/x509-identity-mgmt/ejbca/bin/dojot-custom/configuration-variables.sh
+++ b/x509-identity-mgmt/ejbca/bin/dojot-custom/configuration-variables.sh
@@ -37,7 +37,7 @@ readonly SHARED_VOLUME="/mnt/persistent"
 # (cert|entity)profile_<name>-<id>.xml
 #
 # The directory where the XML files are located
-readonly PROFILES_DIR=${EJBCA_PROFILES_DIR:-"${SHARED_VOLUME}/profiles"}
+readonly PROFILES_DIR="/opt/primekey/profiles"
 #
 # The name of the profiles must not contain spaces!!!
 #

--- a/x509-identity-mgmt/ejbca/bin/dojot-custom/exec.sh
+++ b/x509-identity-mgmt/ejbca/bin/dojot-custom/exec.sh
@@ -136,7 +136,7 @@ function getLock() {
     # obtained by the container, if not, it means that there is already a lock file that has not yet reached
     # the timeout, so it will not be possible to rewrite the lock file while the container that created the
     # lock finishes executing the settings or until the lock timeout is reached.
-    ( set -o noclobber; echo "${HOST_NAME} (${CONTAINER_IP})" > "$LOCK_FILE") 2> /dev/null
+    ( set -o noclobber; echo "${HOST_NAME} (${CONTAINER_IP})" > "$LOCK_FILE")
 }
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

k8s fix

* **What is the current behavior?** (You can also link to an open issue here)

The current behavior is that, during the creation of the docker image (via Dockerfile) the profile files are copied to a directory that is also mapped as a volume, however, as the volume does not yet exist, this is a problem when we try to run the container in a Kubernetes environment.

* **What is the new behavior (if this is a feature change)?**

Because the Dockerfile is copying the EJBCA certificate profiles to a directory that was also mapped as a volume on Kubernetes, it was necessary to change the location of the directory into the container.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

The getLock function has also been changed, the `stderr` redirect has been removed, so if an error occurs when creating the lock file, we will have something printed on the console. Before that, I was giving permission error (the current user in the container was not allowed to create the file on the Kubernetes volume) and we didn't know what it was.