### PR TITLE
Fixed how the Kafka's consumer and producer are configured

### DIFF
--- a/util/microservice-sdk/js/README.md
+++ b/util/microservice-sdk/js/README.md
@@ -150,7 +150,7 @@ The following example illustrates how to use the Consumer:
 const { Kafka: { Consumer } } = require('@dojot/microservice-sdk');
 
 const consumer = new Consumer({
-    kafka: {
+    'kafka.consumer': {
         'group.id': 'sdk-consumer-example',
         'metadata.broker.list': 'localhost:9092',
         }
@@ -183,7 +183,8 @@ The following properties can be set for the Consumer:
 |subscription.backoff.max.ms|The maximum value for the backoff time (in milliseconds). The backoff time is incremented while it is above this value. Default value is 60000.|
 |subscription.backoff.delta.ms|The value that will be used for calculating a random delta time (in milliseconds) in the exponential delay between retries. Default value is 1000.|
 |commit.interval.ms|Time interval (in milliseconds) for committing the processed messages into kafka. A message is committed if and only if all previous messages has been processed. Default value is 5000.|
-|kafka| An object with specific properties for the node-rdkafka consumer. For more details, see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.|
+|kafka.consumer| An object with global properties for the node-rdkafka consumer. For a full list of properties, see: https:/  /github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#global-configuration-properties.|
+|kafka.topic| An object with specific topic configuration properties that applies to all topics the node-rdkafka consumer subscribes to. For a full list of properties, see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties.|
 
 ### Producer
 
@@ -197,7 +198,7 @@ const { Kafka: { Producer } } = require('@dojot/microservice-sdk');
 (async () => {
 
   const producer = new Producer({
-    kafka: {
+    'kafka.producer': {
       'client.id': 'sample-producer',
       'metadata.broker.list': 'kafka:9092',
       dr_cb: true
@@ -230,27 +231,8 @@ The following properties can be set for the Producer:
 |producer.pool.interval.ms    | Polls the producer on this interval, handling disconnections and reconnection. Set it to 0 to turn it off. Default value is 100.|
 |producer.connect.timeout.ms   | Timeout in ms to connect. Default value is 5000.|
 |producer.disconnect.timeout.ms| Timeout in ms to disconnect. Default value is 10000.|
-|**kafka**                     | An object with specific properties for the node-rdkafka producer. More details in Kafka Producer Configuration. |
-
-##### Kafka Producer Configuration
-
-Any property accepted by the producer of node-rdkafka can be set in object **kafka** above mentioned. The most relevant are listed below.
-
-|Property                      |Description|
-|-------                       |----------|
-|enable.idempotence            | When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must be less than or equal to 5), retries=INT32_MAX (must be greater than 0), acks=all, queuing.strategy=fifo. Producer instantiation will fail if user-supplied configuration is incompatible. Default value is false.|
-|acks                          |This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: 0=Broker does not send any response/ack to client, -1 or all=Broker will block until message is committed by all in sync replicas (ISRs). If there are less than min.insync.replicas (broker configuration) in the ISR set the produce request will fail.  Default value is -1.|
-|retries                       |How many times to retry sending a failing Message. Default value is 2.|
-|max.in.flight.requests.per.connection              |This controls how many messages the producer will send to the server without receiving responses. Setting this high can increase memory usage while improving throughput, but setting it too high can reduce throughput as batching becomes less efficient. Setting this to 1 will guarantee that messages will be written to the broker in the order in which they were sent, even when retries occur. Default value is 1000000.|
-|retry.backoff.ms              |The backoff time in milliseconds before retrying a protocol request. Default value is 100.|
-|socket.keepalive.enable       |Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets. Default value is false. |
-|queue.buffering.max.kbytes    |Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than the property queue.buffering.max.messages. Default value is 1048576.|
-|queue.buffering.max.ms        |Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency. Default value is 0.5.|
-|batch.num.messages            |Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by message.max.bytes. Default value is 10000|
-|compression.codec             |Compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property compression.codec. Default value is none|
-|dr_cb                         |This field indicates whether or not a delivery-report will be generated. There is no default value |
-
-For more details, see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
+|kafka.producer| An object with global properties for the node-rdkafka producer. For a full list of the properties, see: https:/  /github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#global-configuration-properties.|
+|kafka.topic| An object with specific topic configuration properties that applies to all topics the node-rdkafka producer produces to. For a full list of the properties, see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties.|
 
 ## Code Examples
 

--- a/util/microservice-sdk/js/examples/consumer/sample.js
+++ b/util/microservice-sdk/js/examples/consumer/sample.js
@@ -17,7 +17,7 @@ const consumer = new Consumer({
   },
   'kafka.topic': {
     'auto.offset.reset': 'beginning',
-  }
+  },
 });
 
 consumer.init().then(() => {

--- a/util/microservice-sdk/js/examples/consumer/sample.js
+++ b/util/microservice-sdk/js/examples/consumer/sample.js
@@ -11,11 +11,13 @@ Logger.setVerbose(true);
 const logger = new Logger('sample-consumer');
 
 const consumer = new Consumer({
-  kafka: {
+  'kafka.consumer': {
     'group.id': process.env.KAFKA_GROUP_ID || 'sdk-consumer-example',
     'metadata.broker.list': process.env.KAFKA_HOSTS || 'localhost:9092',
-    'auto.offset.reset': 'beginning',
   },
+  'kafka.topic': {
+    'auto.offset.reset': 'beginning',
+  }
 });
 
 consumer.init().then(() => {

--- a/util/microservice-sdk/js/examples/producer/sample.js
+++ b/util/microservice-sdk/js/examples/producer/sample.js
@@ -14,7 +14,7 @@ const logger = new Logger('sample-producer');
 
 (async () => {
   const producer = new Producer({
-    kafka: {
+    'kafka.producer': {
       'client.id': process.env.KAFKA_CLIENT_ID || 'sample-producer',
       'metadata.broker.list': process.env.KAFKA_HOSTS || 'kafka:9092',
       dr_cb: true,

--- a/util/microservice-sdk/js/lib/kafka/Consumer.js
+++ b/util/microservice-sdk/js/lib/kafka/Consumer.js
@@ -132,7 +132,7 @@ module.exports = class Consumer {
     this.topicRegExpArray = [];
     // consumer
     this.consumer = new Kafka.KafkaConsumer(this.config['kafka.consumer'],
-    this.config['kafka.topic']);
+      this.config['kafka.topic']);
     // commit manager
     this.commitManager = new CommitManager(this.consumer.commit.bind(this.consumer),
       this.config['commit.interval.ms']);

--- a/util/microservice-sdk/js/lib/kafka/Producer.js
+++ b/util/microservice-sdk/js/lib/kafka/Producer.js
@@ -91,7 +91,8 @@ class Producer {
     this.isReady = false;
     this.producer = new Kafka.Producer(
       this.config['kafka.producer'],
-      this.config['kafka.topic']);
+      this.config['kafka.topic'],
+);
 
     if (this.isDeliveryReportEnabled()) {
       // This will set a callback to be executed everytime a message is published.
@@ -115,8 +116,8 @@ class Producer {
   */
   isDeliveryReportEnabled() {
     return (
-      this.config['kafka.producer'].dr_cb ||
-      this.config['kafka.producer'].dr_msg_cb
+      this.config['kafka.producer'].dr_cb
+      || this.config['kafka.producer'].dr_msg_cb
       );
   }
 

--- a/util/microservice-sdk/js/lib/kafka/Producer.js
+++ b/util/microservice-sdk/js/lib/kafka/Producer.js
@@ -51,15 +51,23 @@ class Producer {
   *    handling disconnections and reconnection. Set it to 0 to turn it off.
   * - "producer.connect.timeout.ms":  Timeout  in ms  to connect
   * - "producer.disconnect.timeout.ms":  Timeout  in ms  to disconnect
-  * - kafka: an object with specific properties for the node-rdkafka consumer. For more details,
-  * see: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+  * - "kafka.producer": an object with global properties for the node-rdkafka producer. For a full
+  *    list of the properties, see:
+  *    https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#global-configuration-properties.
+  * - "kafka.topic": an object with specific topic configuration properties that applies to all
+  *   topics the node-rdkafka producer produces to. For a full list of properties, see:
+  *   https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties.
+  *
   */
   constructor(config) {
     // configuration
     this.config = config || {};
 
-    // kafka consumer configuration
-    this.config.kafka = this.config.kafka || {};
+    // kafka producer configuration
+    this.config['kafka.producer'] = this.config['kafka.producer'] || {};
+
+    // kafka topic configuration
+    this.config['kafka.topic'] = this.config['kafka.topic'] || {};
 
     this.config['producer.flush.timeout.ms'] = (
       this.config['producer.flush.timeout.ms'] || PRODUCER_FLUSH_TIMEOUT_MS
@@ -81,7 +89,9 @@ class Producer {
 
 
     this.isReady = false;
-    this.producer = new Kafka.Producer(this.config.kafka);
+    this.producer = new Kafka.Producer(
+      this.config['kafka.producer'],
+      this.config['kafka.topic']);
 
     if (this.isDeliveryReportEnabled()) {
       // This will set a callback to be executed everytime a message is published.
@@ -104,7 +114,10 @@ class Producer {
   * @private
   */
   isDeliveryReportEnabled() {
-    return this.config.kafka.dr_cb || this.config.kafka.dr_msg_cb;
+    return (
+      this.config['kafka.producer'].dr_cb ||
+      this.config['kafka.producer'].dr_msg_cb
+      );
   }
 
   /**

--- a/util/microservice-sdk/js/lib/kafka/Producer.js
+++ b/util/microservice-sdk/js/lib/kafka/Producer.js
@@ -92,7 +92,7 @@ class Producer {
     this.producer = new Kafka.Producer(
       this.config['kafka.producer'],
       this.config['kafka.topic'],
-);
+    );
 
     if (this.isDeliveryReportEnabled()) {
       // This will set a callback to be executed everytime a message is published.
@@ -118,7 +118,7 @@ class Producer {
     return (
       this.config['kafka.producer'].dr_cb
       || this.config['kafka.producer'].dr_msg_cb
-      );
+    );
   }
 
   /**

--- a/util/microservice-sdk/js/npm-shrinkwrap.json
+++ b/util/microservice-sdk/js/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/microservice-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2091,14 +2091,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2113,20 +2111,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2243,8 +2238,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2256,7 +2250,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2271,7 +2264,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2279,14 +2271,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2305,7 +2295,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -2367,8 +2356,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -2396,8 +2384,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2409,7 +2396,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2523,7 +2509,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3859,9 +3844,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/util/microservice-sdk/js/package.json
+++ b/util/microservice-sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojot/microservice-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A SDK to help to build microservices for the dojot platform",
   "scripts": {
     "test": "jest",

--- a/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
+++ b/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
@@ -88,9 +88,10 @@ test('Constructor: default', () => {
     'subscription.backoff.max.ms': 60000,
     'subscription.backoff.delta.ms': 1000,
     'commit.interval.ms': 5000,
-    kafka: {
+    'kafka.consumer': {
       'enable.auto.commit': false,
     },
+    'kafka.topic': {}
   };
 
   // check
@@ -101,7 +102,7 @@ test('Constructor: default', () => {
 });
 
 test('Constructor: divergent value for enable.auto.commit', () => {
-  const consumer = new Consumer({ kafka: { 'enable.auto.commit': true } });
+  const consumer = new Consumer({ 'kafka.consumer': { 'enable.auto.commit': true } });
   const expectedConfig = {
     'in.processing.max.messages': 1,
     'queued.max.messages.bytes': 10485760,
@@ -109,9 +110,10 @@ test('Constructor: divergent value for enable.auto.commit', () => {
     'subscription.backoff.max.ms': 60000,
     'subscription.backoff.delta.ms': 1000,
     'commit.interval.ms': 5000,
-    kafka: {
+    'kafka.consumer': {
       'enable.auto.commit': false, // it must be disabled!
     },
+    'kafka.topic': {}
   };
 
   // check
@@ -120,6 +122,38 @@ test('Constructor: divergent value for enable.auto.commit', () => {
   expect(consumer.commitManager).not.toBeNull();
   expect(consumer.msgQueue).not.toBeNull();
 });
+
+
+test('Constructor: consumer and topic properties', () => {
+  const consumer = new Consumer({
+    'kafka.consumer': {
+      'bootstrap.servers': ['kafka.server1', 'kafka.server2']
+    },
+   'kafka.topic': {
+    'auto.offset.reset': 'beginning'
+   }
+  });
+  const expectedConfig = {
+    'in.processing.max.messages': 1,
+    'queued.max.messages.bytes': 10485760,
+    'subscription.backoff.min.ms': 1000,
+    'subscription.backoff.max.ms': 60000,
+    'subscription.backoff.delta.ms': 1000,
+    'commit.interval.ms': 5000,
+    'kafka.consumer': {
+      'bootstrap.servers': ['kafka.server1', 'kafka.server2']
+    },
+    'kafka.topic': {
+      'auto.offset.reset': 'beginning'
+    }
+  };
+
+  // check
+  expect(consumer.config).toMatchObject(expectedConfig);
+  expect(consumer.consumer).not.toBeNull();
+  expect(consumer.commitManager).not.toBeNull();
+  expect(consumer.msgQueue).not.toBeNull();
+})
 
 test('Basic initialization', async () => {
   const consumer = new Consumer();

--- a/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
+++ b/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
@@ -129,9 +129,9 @@ test('Constructor: consumer and topic properties', () => {
     'kafka.consumer': {
       'bootstrap.servers': ['kafka.server1', 'kafka.server2'],
     },
-   'kafka.topic': {
-    'auto.offset.reset': 'beginning',
-   },
+    'kafka.topic': {
+      'auto.offset.reset': 'beginning',
+    },
   });
   const expectedConfig = {
     'in.processing.max.messages': 1,

--- a/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
+++ b/util/microservice-sdk/js/test/unit/kafka/Consumer.test.js
@@ -91,7 +91,7 @@ test('Constructor: default', () => {
     'kafka.consumer': {
       'enable.auto.commit': false,
     },
-    'kafka.topic': {}
+    'kafka.topic': {},
   };
 
   // check
@@ -113,7 +113,7 @@ test('Constructor: divergent value for enable.auto.commit', () => {
     'kafka.consumer': {
       'enable.auto.commit': false, // it must be disabled!
     },
-    'kafka.topic': {}
+    'kafka.topic': {},
   };
 
   // check
@@ -127,11 +127,11 @@ test('Constructor: divergent value for enable.auto.commit', () => {
 test('Constructor: consumer and topic properties', () => {
   const consumer = new Consumer({
     'kafka.consumer': {
-      'bootstrap.servers': ['kafka.server1', 'kafka.server2']
+      'bootstrap.servers': ['kafka.server1', 'kafka.server2'],
     },
    'kafka.topic': {
-    'auto.offset.reset': 'beginning'
-   }
+    'auto.offset.reset': 'beginning',
+   },
   });
   const expectedConfig = {
     'in.processing.max.messages': 1,
@@ -141,11 +141,11 @@ test('Constructor: consumer and topic properties', () => {
     'subscription.backoff.delta.ms': 1000,
     'commit.interval.ms': 5000,
     'kafka.consumer': {
-      'bootstrap.servers': ['kafka.server1', 'kafka.server2']
+      'bootstrap.servers': ['kafka.server1', 'kafka.server2'],
     },
     'kafka.topic': {
-      'auto.offset.reset': 'beginning'
-    }
+      'auto.offset.reset': 'beginning',
+    },
   };
 
   // check
@@ -153,7 +153,7 @@ test('Constructor: consumer and topic properties', () => {
   expect(consumer.consumer).not.toBeNull();
   expect(consumer.commitManager).not.toBeNull();
   expect(consumer.msgQueue).not.toBeNull();
-})
+});
 
 test('Basic initialization', async () => {
   const consumer = new Consumer();

--- a/util/microservice-sdk/js/test/unit/kafka/Producer.test.js
+++ b/util/microservice-sdk/js/test/unit/kafka/Producer.test.js
@@ -18,10 +18,13 @@ jest.useFakeTimers();
 
 describe('Kafka producer', () => {
   const mockConfig = {
-    kafka: {
+    'kafka.producer': {
       'metadata.broker.list': 'kafka:9092',
       dr_cb: true,
     },
+    'kafka.topic': {
+      'request.required.acks': -1
+    }
   };
   const mockKafka = {
     producer: {

--- a/util/microservice-sdk/js/test/unit/kafka/Producer.test.js
+++ b/util/microservice-sdk/js/test/unit/kafka/Producer.test.js
@@ -23,8 +23,8 @@ describe('Kafka producer', () => {
       dr_cb: true,
     },
     'kafka.topic': {
-      'request.required.acks': -1
-    }
+      'request.required.acks': -1,
+    },
   };
   const mockKafka = {
     producer: {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
It is not possible to pass topic specific settings to the Kafka's consumer and producer.


* **What is the new behavior (if this is a feature change)?**
Now it's possible to pass both global and topic specific configurations to the Kafka's consumer and producer.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

This PR changes the way the Kafka's consumer and producer are configured. The services that uses the SDK should be changed to use this new version as soon as possible.

* **Other information**:

This PR is related to #1558 