### PR TITLE
[release] Fix Locust Docker files

### DIFF
--- a/connector/mqtt/locust/Docker/docker-compose-master.yml
+++ b/connector/mqtt/locust/Docker/docker-compose-master.yml
@@ -4,16 +4,22 @@ services:
     image: dojot/locust:v0.5.0-alpha.2
     command: bash master_entrypoint.sh
     volumes:
-      - ..:/usr/src/app
+      # If you need to change code while running the container, activate this volume:
+      # - ..:/usr/src/app
+      # If you only need to generate certificates, activate this volume instead:
+      - ../cert:/usr/src/app/cert
     environment:
       DOJOT_URL: "http://127.0.0.1:8000"
       DOJOT_MQTT_HOST: "127.0.0.1"
       # TODO: differentiate DOJOT_MQTT_PORT and DOJOT_MQTTS_PORT variables
       DOJOT_MQTT_PORT: "1883"
       DOJOT_MQTT_TIMEOUT: "120"
+      DOJOT_ENV: "n"
+
+      REDIS_HOST: "redis"
+      REDIS_PORT: "6379"
       REDIS_PASSWD: ""
       REDIS_BACKUP: "y"
-      DOJOT_ENV: "n"
     networks:
       - default
     depends_on:

--- a/connector/mqtt/locust/Docker/docker-compose-slave.yml
+++ b/connector/mqtt/locust/Docker/docker-compose-slave.yml
@@ -4,21 +4,26 @@ services:
     image: dojot/locust:v0.5.0-alpha.2
     command: bash slave_entrypoint.sh
     volumes:
-      - ..:/usr/src/app
+      # If you need to change code while running the container, activate this volume:
+      # - ..:/usr/src/app
+      # If you only need to generate certificates, activate this volume instead:
+      - ../cert:/usr/src/app/cert
     environment:
       DOJOT_URL: "http://127.0.0.1:8000"
       DOJOT_MQTT_HOST: "127.0.0.1"
       # TODO: differentiate DOJOT_MQTT_PORT and DOJOT_MQTTS_PORT variables
       DOJOT_MQTT_PORT: "1883"
       DOJOT_MQTT_TIMEOUT: "120"
+      DOJOT_ENV: "n"
+
       LOCUST_MASTER_HOST: "locust-master"
+
       REDIS_HOST: "redis"
       REDIS_PORT: "6379"
       REDIS_PASSWD: ""
+
       TASK_MIN_TIME: "29500"
       TASK_MAX_TIME: "30000"
-      EJBCA_URL: "http://localhost:5583"
-      LOG_LEVEL: "info"
 
       RENEW_DEVICES: "False"
       DEVICES_TO_RENEW: 1000

--- a/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
@@ -2,9 +2,10 @@ FROM python:3.6-alpine3.10
 
 WORKDIR /usr/src/app
 
-COPY . .
+COPY ./requirements ./requirements
+COPY ./src ./src
 
-RUN apk add --no-cache \
+RUN apk add \
     curl \
     bash \
     gcc \
@@ -14,14 +15,13 @@ RUN apk add --no-cache \
     openssl-dev \
     redis
 
-RUN pip install --no-cache-dir -r requirements/prod.txt
-RUN pip install --no-cache-dir -r requirements/dev.txt
+RUN pip install -r requirements/prod.txt
+RUN pip install -r requirements/dev.txt
 
 RUN touch ~/.bashrc
 RUN echo "alias generate_certs='python -m src.scripts.generate_certs'" >> ~/.bashrc
 RUN echo "alias run_cov='coverage run -m pytest tests && coverage html'" >> ~/.bashrc
 RUN echo "alias run_lint='pylint src --rcfile=.pylintrc tests --rcfile=.pylintrc'" >> ~/.bashrc
 
-# This command will do nothing and prevent the container from exiting
-# from lack of commands
+# This command will do nothing and prevent the container from exiting from lack of commands
 CMD tail -f /dev/null

--- a/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY ./requirements ./requirements
 COPY ./src ./src
 
-RUN apk add \
+RUN apk add --no-cache \
     curl \
     bash \
     gcc \

--- a/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
@@ -1,16 +1,19 @@
 version: "3"
 services:
   generate-certs:
-    image: dojot/generate_certs:development
+    build:
+      context: ../../../
+      dockerfile: ./Docker/scripts/generate_certs/Dockerfile
     volumes:
-      - ../../..:/usr/src/app
+      # If you need to change code while running the container, activate this volume:
+      # - ../../..:/usr/src/app
+      # If you only need to generate certificates, activate this volume instead:
+      - ../../../cert:/usr/src/app/cert
     environment:
       DOJOT_URL: "http://127.0.0.1:8000"
       DOJOT_MQTT_HOST: "127.0.0.1"
       DOJOT_MQTT_PORT: "1883"
       DOJOT_ENV: "n"
-
-      EJBCA_URL: "http://localhost:5583"
 
       REDIS_HOST: "redis"
       REDIS_PORT: "6379"

--- a/connector/mqtt/locust/master_entrypoint.sh
+++ b/connector/mqtt/locust/master_entrypoint.sh
@@ -14,7 +14,7 @@ readonly DOJOT_MQTT_PORT=${DOJOT_MQTT_PORT:-"1883"}
 
 # Redis parameters
 readonly REDIS_CONN_TIMEOUT=${REDIS_CONN_TIMEOUT:-"180"}
-readonly REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
+readonly REDIS_HOST=${REDIS_HOST:-"redis"}
 readonly REDIS_PORT=${REDIS_PORT:-"6379"}
 readonly REDIS_PASSWD=${REDIS_PASSWD:-""}
 # Databases

--- a/connector/mqtt/locust/slave_entrypoint.sh
+++ b/connector/mqtt/locust/slave_entrypoint.sh
@@ -8,11 +8,11 @@ readonly DOJOT_MQTT_PORT=${DOJOT_MQTT_PORT:-"1883"}
 readonly DOJOT_MQTT_TIMEOUT=${DOJOT_MQTT_TIMEOUT:-"60"}
 
 # Locust parameters
-readonly LOCUST_MASTER_HOST=${LOCUST_MASTER_HOST:-"127.0.0.1"}
+readonly LOCUST_MASTER_HOST=${LOCUST_MASTER_HOST:-"locust-master"}
 
 # Redis parameters
 readonly REDIS_CONN_TIMEOUT=${REDIS_CONN_TIMEOUT:-"180"}
-readonly REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
+readonly REDIS_HOST=${REDIS_HOST:-"redis"}
 readonly REDIS_PORT=${REDIS_PORT:-"6379"}
 readonly REDIS_PASSWD=${REDIS_PASSWD:-""}
 

--- a/connector/mqtt/locust/src/config.py
+++ b/connector/mqtt/locust/src/config.py
@@ -12,7 +12,7 @@ CONFIG = {
     'security': {
         'devices_to_renew':           int(os.environ.get("DEVICES_TO_RENEW", 1000)),
         'devices_to_revoke':          int(os.environ.get("DEVICES_TO_REVOKE", 1000)),
-        'dns_cert':                   [],    
+        'dns_cert':                   [],
         'renew_devices':              Utils.str_to_bool(os.environ.get("RENEW_DEVICES", "False")),
         'revoke_devices':             Utils.str_to_bool(os.environ.get("REVOKE_DEVICES", "False")),
         'cert_dir':                   os.environ.get("CERT_DIR", "cert/"),
@@ -33,7 +33,7 @@ CONFIG = {
         'redis': {
             'certificates_db':      int(os.environ.get("REDIS_CERTIFICATES_DB", 0)),
             'mapped_db':            int(os.environ.get("REDIS_MAPPED_DB", 1)),
-            'host':                 os.environ.get("REDIS_HOST", "127.0.0.1"),
+            'host':                 os.environ.get("REDIS_HOST", "redis"),
             'port':                 int(os.environ.get("REDIS_PORT", 6379)),
             'jwt_expire_time':      int(os.environ.get("REDIS_STORED_JWT_EXPIRE_TIME", 1800)),
         }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix and enhancement

* **What is the current behavior?** (You can also link to an open issue here)
- Generate certs script image is being retrieved from Dojot Docker Hub, but it is not necessary to send the image to it
- All Docker Compose files were creating volumes for all files and directories, but this is necessary only when developing

* **What is the new behavior (if this is a feature change)?**
- Generate certs image can now be built locally
- Docker Compose files have now a commented volume for developers and has only the `cert` directory mapped by default
- Fixed environment variables with wrong default values (such as REDIS_HOST default value of "127.0.0.1" instead of "redis")

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Other information**:
