### PR TITLE
validating inputs and sanitizing outputs

### DIFF
--- a/x509-identity-mgmt/js/package-lock.json
+++ b/x509-identity-mgmt/js/package-lock.json
@@ -3794,8 +3794,7 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+          "resolved": ""
         },
         "lodash.sortby": {
           "version": "4.7.0",
@@ -10519,9 +10518,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/x509-identity-mgmt/js/tests/integration/cert-get.test.js
+++ b/x509-identity-mgmt/js/tests/integration/cert-get.test.js
@@ -24,10 +24,13 @@ describe('X509 Certificates - GET integrations', () => {
       const fingerprint = '2A:38:A7:01:28:42:C0:18:56:1E:99:5E:F0:9A:BE:AD:D8:4D:E0:C8:3E:4F:08:4D:01:B8:47:DD:58:DC:70:AD';
       const queryResult = {
         fingerprint,
+        belongsTo: {
+          device: null,
+        },
       };
-      db.certificate.model.exec.mockResolvedValue(queryResult);
+      db.certificate.model.exec.mockResolvedValue({ ...queryResult, _id: '123456' });
 
-      return req.get(`/api/v1/certificates/${fingerprint}?fields=fingerprint`)
+      return req.get(`/api/v1/certificates/${fingerprint}?fields=fingerprint,belongsTo`)
         .set('Authorization', `Bearer ${token}`)
         .send()
         .expect(200)
@@ -52,16 +55,32 @@ describe('X509 Certificates - GET integrations', () => {
         });
     });
 
+  it('should throw an invalid field error',
+    () => {
+      const fingerprint = '2A:38:A7:01:28:42:C0:18:56:1E:99:5E:F0:9A:BE:AD:D8:4D:E0:C8:3E:4F:08:4D:01:B8:47:DD:58:DC:70:AD';
+      db.certificate.model.exec.mockResolvedValue(null);
+
+      return req.get(`/api/v1/certificates/${fingerprint}?fields=fingerPrint,_id`)
+        .set('Authorization', `Bearer ${token}`)
+        .send()
+        .expect(400)
+        .then((res) => {
+          expect(res.body).toEqual({
+            message: 'The fields provided are not valid: [fingerPrint,_id]',
+          });
+        });
+    });
+
   it('should get a list of certificates',
     () => {
       const fingerprint1 = '2A:38:A7:01:28:42:C0:18:56:1E:99:5E:F0:9A:BE:AD:D8:4D:E0:C8:3E:4F:08:4D:01:B8:47:DD:58:DC:70:AD';
       const fingerprint2 = '26:E9:8C:28:1F:9D:E9:D3:FF:5E:6B:11:9B:E2:DA:FC:5C:A6:36:F1:15:B2:19:35:E9:71:2B:E1:01:AD:93:32';
       const fingerprint3 = '99:5C:B8:C0:2D:FA:A0:DE:60:2C:0E:C0:97:76:0A:A8:1F:9B:BD:08:1F:7B:A5:10:58:5F:07:D6:25:4E:83:49';
-      const results = {
-        fingerprint1,
-        fingerprint2,
-        fingerprint3,
-      };
+      const results = [
+        { fingerprint: fingerprint1 },
+        { fingerprint: fingerprint2 },
+        { fingerprint: fingerprint3 },
+      ];
       db.certificate.model.exec.mockResolvedValue(results);
       db.certificate.model.count.mockResolvedValue(3);
 
@@ -92,11 +111,11 @@ describe('X509 Certificates - GET integrations', () => {
       const fingerprint1 = '2A:38:A7:01:28:42:C0:18:56:1E:99:5E:F0:9A:BE:AD:D8:4D:E0:C8:3E:4F:08:4D:01:B8:47:DD:58:DC:70:AD';
       const fingerprint2 = '26:E9:8C:28:1F:9D:E9:D3:FF:5E:6B:11:9B:E2:DA:FC:5C:A6:36:F1:15:B2:19:35:E9:71:2B:E1:01:AD:93:32';
       const fingerprint3 = '99:5C:B8:C0:2D:FA:A0:DE:60:2C:0E:C0:97:76:0A:A8:1F:9B:BD:08:1F:7B:A5:10:58:5F:07:D6:25:4E:83:49';
-      const results = {
-        fingerprint1,
-        fingerprint2,
-        fingerprint3,
-      };
+      const results = [
+        { fingerprint: fingerprint1 },
+        { fingerprint: fingerprint2 },
+        { fingerprint: fingerprint3 },
+      ];
       db.certificate.model.exec.mockResolvedValue(results);
       db.certificate.model.count.mockResolvedValue(3);
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

When an invalid query field was informed, it was only disregarded in the projection of the result.

* **What is the new behavior (if this is a feature change)?**

If the query field is invalid, an error will be issued alerting the client of the api

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:

In addition to checking the query fields, an additional mechanism was also implemented to sanitize the response given by the API.
Before, only the projection functionality of MongoDB was used, but we noticed that in certain cases the `_id` attribute was still returned. For some reason, the _mongoose_ also returned the `__v` field. Therefore, a function was implemented that is capable of cleaning the return object to contain only the allowed attributes.