### PR TITLE
[Release-v0.5.0] End kafka-ws process when a rejected promise is not handled anywhere

### DIFF
--- a/subscription-engine/kafka-ws/index.js
+++ b/subscription-engine/kafka-ws/index.js
@@ -64,6 +64,9 @@ process.on('unhandledRejection', (reason, promise) => {
   unhandledRejections.set(promise, reason);
 
   logger.debug(`unhandledRejection: List of Unhandled Rejection size ${unhandledRejections.size}`);
+
+  // TODO: stop server (connection redis, kafka consumer, etc.)
+  process.kill(process.pid);
 });
 
 process.on('rejectionHandled', (promise) => {

--- a/subscription-engine/kafka-ws/index.js
+++ b/subscription-engine/kafka-ws/index.js
@@ -46,7 +46,12 @@ server.listen(serverCfg.port, serverCfg.host, async () => {
   logger.info(server.address());
 
   // Initializes the sticky tarball
-  await websocketTarball.init();
+  try {
+    await websocketTarball.init();
+  } catch (err) {
+    logger.error('Unexpected service startup error!', err)
+    process.kill(process.pid);
+  }
 });
 
 /* adds health checks and graceful shutdown to the application */
@@ -64,9 +69,6 @@ process.on('unhandledRejection', (reason, promise) => {
   unhandledRejections.set(promise, reason);
 
   logger.debug(`unhandledRejection: List of Unhandled Rejection size ${unhandledRejections.size}`);
-
-  // TODO: stop server (connection redis, kafka consumer, etc.)
-  process.kill(process.pid);
 });
 
 process.on('rejectionHandled', (promise) => {

--- a/subscription-engine/kafka-ws/index.js
+++ b/subscription-engine/kafka-ws/index.js
@@ -49,7 +49,7 @@ server.listen(serverCfg.port, serverCfg.host, async () => {
   try {
     await websocketTarball.init();
   } catch (err) {
-    logger.error('Unexpected service startup error!', err)
+    logger.error('Unexpected service startup error!', err);
     process.kill(process.pid);
   }
 });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The kafka-ws process fails to create a consumer kafka and runs, but without returning anything to websocket clients.

* **What is the new behavior (if this is a feature change)?**

End kafka-ws process when a rejected promise is not handled anywhere

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR?** (Link to an issue, e.g. #99999)

dojot/dojot#1825

* **Other information**:

This is a workaround for the problem