### PR TITLE
[locust] Change generate-certs base image to the Locust one

### DIFF
--- a/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/Dockerfile
@@ -1,25 +1,12 @@
-FROM python:3.6-alpine3.10
+FROM dojot/locust:development
 
 WORKDIR /usr/src/app
 
 COPY ./requirements ./requirements
-COPY ./src ./src
-
-RUN apk add --no-cache \
-    curl \
-    bash \
-    gcc \
-    g++ \
-    libffi-dev \
-    make \
-    openssl-dev \
-    redis
-
-RUN pip install -r requirements/prod.txt
 RUN pip install -r requirements/dev.txt
 
 RUN touch ~/.bashrc
-RUN echo "alias generate_certs='python -m src.scripts.generate_certs'" >> ~/.bashrc
+RUN echo "alias generate_certs='python3 -m src.scripts.generate_certs'" >> ~/.bashrc
 RUN echo "alias run_cov='coverage run -m pytest tests && coverage html'" >> ~/.bashrc
 RUN echo "alias run_lint='pylint src --rcfile=.pylintrc tests --rcfile=.pylintrc'" >> ~/.bashrc
 

--- a/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
+++ b/connector/mqtt/locust/Docker/scripts/generate_certs/docker-compose.yml
@@ -5,9 +5,13 @@ services:
       context: ../../../
       dockerfile: ./Docker/scripts/generate_certs/Dockerfile
     volumes:
-      # If you need to change code while running the container, activate this volume:
+      # If you are developing using this container, activate these volumes:
       # - ../../../src:/usr/src/app/src
-      # If you only need to generate certificates, activate this volume instead:
+      # - ../../../tests:/usr/src/app/tests
+      # - ../../../.pylintrc:/usr/src/app/.pylintrc
+      # - ../../../requirements:/usr/src/app/requirements
+      # Whether you are developing or running a test, this volume should be active to properly load
+      # the certificates:
       - ../../../cert:/usr/src/app/cert
     environment:
       DOJOT_URL: "http://127.0.0.1:8000"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Enhancement.

* **What is the current behavior?** (You can also link to an open issue here)
We are using the Python image, but the problem is that the image can take so much time to build because of the Locust library installation.

* **What is the new behavior (if this is a feature change)?**
We changed the base image to the dojot/locust one, so we don't have to install the Locust lib every time.
It also add new volumes in the generate-certs Docker Compose.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR?** (Link to an issue, e.g. #99999)


* **Other information**:
