### PR TITLE
[v0.5.1] [influxdb-retriever] Allow Reserved for date-time

### DIFF
--- a/storage/time-series/influxdb/retriever/api/v1.yml
+++ b/storage/time-series/influxdb/retriever/api/v1.yml
@@ -131,6 +131,7 @@ components:
 
           It must be `greater` than or `equal` to `1970-01-01T00:00:00.000Z`
       required: false
+      allowReserved: true
       examples:
         init:
           summary: Minimum possible date-time
@@ -151,6 +152,7 @@ components:
 
         It must be `greater` than the `dateFrom`.
       required: false
+      allowReserved: true
       examples:
         future:
           summary: An example of a date-time in the future


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

* **Other information**:

from https://swagger.io/docs/specification/serialization/

> Additionally, the allowReserved keyword specifies whether the reserved characters :/?#[]@!$&'()*+,;= in parameter values are allowed to be sent as they are, or should be percent-encoded. By default, allowReserved is false, and reserved characters are percent-encoded. For example, / is encoded as %2F (or %2f), so that the parameter value quotes/h2g2.txt will be sent as quotes%2Fh2g2.txt
