### PR TITLE
[development][fix] check x509-identity-mgmt readiness

### DIFF
--- a/connector/mqtt/vernemq/broker/bin/vmq_dojot/vmq_dojot.sh
+++ b/connector/mqtt/vernemq/broker/bin/vmq_dojot/vmq_dojot.sh
@@ -46,12 +46,13 @@ _connectEJBCA()
   START_TIME=$(date +'%s')
   echo "Waiting for dojot EJBCA Broker fully start. Host ${EJBCA_ADDRESS}..."
   echo "Try to connect to dojot EJBCA Broker ... "
-  RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
-  echo "$RESPONSE"
-  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '"ok"' ]; do
+
+  RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
+  echo "EJBCA Broker HTTP response: $RESPONSE"
+  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '200' ]; do
       sleep 30
       echo "Retry to connect to dojot EJBCA broker ... "
-      RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
+      RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
 
       ELAPSED_TIME=$(($(date +'%s') - ${START_TIME}))
       if [ ${ELAPSED_TIME} -gt 180 ]

--- a/connector/mqtt/vernemq/k2v-bridge/bin/scripts_tls/ejbca_client.sh
+++ b/connector/mqtt/vernemq/k2v-bridge/bin/scripts_tls/ejbca_client.sh
@@ -41,12 +41,13 @@ _connectEJBCA()
   START_TIME=$(date +'%s')
   echo "Waiting for dojot EJBCA Broker fully start. Adress '${K2V_APP_EJBCA_ADDRESS}'..."
   echo "Try to connect to dojot EJBCA Broker ... "
-  RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
-  echo "$RESPONSE"
-  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '"ok"' ]; do
+
+  RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
+  echo "EJBCA Broker HTTP response: $RESPONSE"
+  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '200' ]; do
       sleep 30
       echo "Retry to connect to dojot EJBCA broker ... "
-      RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
+      RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
 
       ELAPSED_TIME=$(($(date +'%s') - ${START_TIME}))
       if [ ${ELAPSED_TIME} -gt 180 ]

--- a/connector/mqtt/vernemq/v2k-bridge/bin/scripts_tls/ejbca_client.sh
+++ b/connector/mqtt/vernemq/v2k-bridge/bin/scripts_tls/ejbca_client.sh
@@ -41,12 +41,13 @@ _connectEJBCA()
   START_TIME=$(date +'%s')
   echo "Waiting for dojot EJBCA Broker fully start. Adress '${V2K_APP_EJBCA_ADDRESS}'..."
   echo "Try to connect to dojot EJBCA Broker ... "
-  RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
-  echo "$RESPONSE"
-  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '"ok"' ]; do
+
+  RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
+  echo "EJBCA Broker HTTP response: $RESPONSE"
+  while [ -z "${RESPONSE}" ] || [ "${RESPONSE}" != '200' ]; do
       sleep 30
       echo "Retry to connect to dojot EJBCA broker ... "
-      RESPONSE=$( (curl --fail -s "${certEjbcaApiUrl}/healthcheck" || echo "") | jq '.status')
+      RESPONSE=$(curl -s -o '/dev/null' -w '%{http_code}' -m '10' -I -X GET "${certEjbcaApiUrl}/internal/api/v1/throw-away/ca")
 
       ELAPSED_TIME=$(($(date +'%s') - ${START_TIME}))
       if [ ${ELAPSED_TIME} -gt 180 ]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

VerneMQ, V2K and K2V were checking that the x509-identity-mgmt was standing, but at an endpoint that no longer exists.

* **What is the new behavior (if this is a feature change)?**

A workaround was made to verify that the x509-identity-mgmt is ready. This solution was made because it is not yet known whether the health check port will be opened in the kubernetes.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#1969

* **Other information**:
