### PR TITLE
Flag-enabled SubjectDN and DeviceExists validations

### DIFF
--- a/iam/x509-identity-mgmt/README.md
+++ b/iam/x509-identity-mgmt/README.md
@@ -42,6 +42,7 @@ entities, that is, *IoT devices* that communicate with the dojot IoT platform.
       - [Logger Settings](#logger-settings)
       - [Kafka Integration Settings](#kafka-integration-settings)
       - [_Device Manager_ Integration Settings](#device-manager-integration-settings)
+      - [Certificate Service Settings](#certificate-service-settings)
     - [How to run](#how-to-run)
   - [Debugging the service](#debugging-the-service)
   - [Testing the service](#testing-the-service)
@@ -123,7 +124,7 @@ Explaining this command in detail:
 | -sha256                                    | This specifies the message digest to sign the request. |
 | -keyout private.key                        | This gives the filename to write the newly created private key to. |
 | -out request.csr                           | This specifies the output filename to write the CSR to |
-| -subj "/CN=`{device-id here}`" | Sets subject name for new request. <br> **Important note**: Only the CN (CommonName) is required. The value of this field must match the *device identifier*. The dojot platform is responsible for adding the correct *tenant*. In this way, the *Certificate-Device* relationship is made. |
+| -subj "/CN=`{device-id here}`" | Sets subject name for new request. Only the CN (CommonName) is required. This field can contain any value. In the past, this field was used to link the `tenant:device-id` to the certificate, but this behavior has been disabled to support external certificates. |
 
 For more details, just consult the tool manual:
 
@@ -1118,7 +1119,8 @@ fore mentioned convention.
 | certificate.subject.mandatoryattrs | string[] | `["CN"]` | | X509IDMGMT_CERTIFICATE_SUBJECT_MANDATORYATTRS | Mandatory fields that must be present in the CSR |
 | certificate.subject.constantattrs.o | string | `dojot IoT Platform` | | X509IDMGMT_CERTIFICATE_SUBJECT_CONSTANTATTRS_O | In particular, the SubjectDN *Organization* field has a constant value and cannot be changed by a CSR. |
 | certificate.validity | integer | `365` | positive values | X509IDMGMT_CERTIFICATE_VALIDITY | certificate validity (in days). |
-| certificate.checkpublickey | boolean | `true` | `true` or `false` | X509IDMGMT_CERTIFICATE_CHECKPUBLICKEY | Flag indicating whether the CSR public key validation should be performed or not. |
+| certificate.check.publickey | boolean | `true` | `true` or `false` | X509IDMGMT_CERTIFICATE_CHECK_PUBLICKEY | Flag indicating whether the CSR public key validation should be performed or not. |
+| certificate.check.subjectdn | boolean | `false` | `true` or `false` | X509IDMGMT_CERTIFICATE_CHECK_SUBJECTDN | Flag indicating whether the CSR SubjectDN field validation should be performed or not. |
 | certificate.external.minimumvaliditydays | integer | `1` | positive values | X509IDMGMT_CERTIFICATE_EXTERNAL_MINIMUMVALIDITYDAYS | Minimum validity (in days) that the external certificate must still have before it can be registered. |
 | certificate.external.ca.minimumvaliditydays | integer | `1` | positive values | X509IDMGMT_CERTIFICATE_EXTERNAL_CA_MINIMUMVALIDITYDAYS | Minimum validity (in days) that the external CA certificate must still have before it can be registered. |
 | certificate.external.ca.limit | integer | `-1` | | X509IDMGMT_CERTIFICATE_EXTERNAL_CA_LIMIT | Limit of certificates from external CAs that can be registered by tenant. Any negative value indicates that there will be no limit on the number of CA certificates that can be registered by tenants. |
@@ -1183,6 +1185,13 @@ fore mentioned convention.
 | devicemgr.device.timeout.ms | integer | `10000` (10 seconds) | `[0,...]` | X509IDMGMT_DEVICEMGR_DEVICE_TIMEOUT_MS | _Device Manager_ response timeout |
 | devicemgr.kafka.consumer.topic.suffix | string | `dojot.device-manager.device` | - | X509IDMGMT_DEVICEMGR_KAFKA_CONSUMER_TOPIC_SUFFIX | Suffix of the same topics that _Device Manager_ publishes data according to its events. |
 | devicemgr.healthcheck.ms | integer | `10000` (10 seconds) | `[0,...]` | X509IDMGMT_DEVICEMGR_HEALTHCHECK_MS | Time interval in which the Kafka consumer who consumes _Device Manager_ events is checked to see if he is healthy |
+
+
+#### Certificate Service Settings
+
+| Key | type | Default Value | Valid Values | Environment variable | Purpose |
+|-----|------|---------------|--------------|----------------------|---------|
+| certservice.check.device.exists | boolean | `true` | `true` or `false` | X509IDMGMT_CERTSERVICE_CHECK_DEVICE_EXISTS | Flag indicating whether the device's existence check should be performed or not. |
 
 
 ### How to run

--- a/iam/x509-identity-mgmt/js/config/default.conf
+++ b/iam/x509-identity-mgmt/js/config/default.conf
@@ -158,10 +158,15 @@ certificate.subject.constantattrs.o:string=dojot IoT Platform
 # -------------------------------
 certificate.validity:integer=365
 
-# -------------------------------------
-# X509IDMGMT_CERTIFICATE_CHECKPUBLICKEY
-# -------------------------------------
-certificate.checkpublickey:boolean=true
+# --------------------------------------
+# X509IDMGMT_CERTIFICATE_CHECK_PUBLICKEY
+# --------------------------------------
+certificate.check.publickey:boolean=true
+
+# --------------------------------------
+# X509IDMGMT_CERTIFICATE_CHECK_SUBJECTDN
+# --------------------------------------
+certificate.check.subjectdn:boolean=false
 
 # ---------------------------------------------------
 # X509IDMGMT_CERTIFICATE_EXTERNAL_MINIMUMVALIDITYDAYS
@@ -521,3 +526,15 @@ notifications.kafka.producer.ownership.topic.suffix:string=dojot.x509-identity-m
 # X509IDMGMT_NOTIFICATIONS_KAFKA_PRODUCER_TRUSTEDCA_TOPIC_SUFFIX
 # --------------------------------------------------------------
 notifications.kafka.producer.trustedca.topic.suffix:string=dojot.x509-identity-mgmt.trusted-cas
+
+
+# ******************************************************************************
+
+# ===================
+# Certificate Service
+# ===================
+
+# ------------------------------------------
+# X509IDMGMT_CERTSERVICE_CHECK_DEVICE_EXISTS
+# ------------------------------------------
+certservice.check.device.exists:boolean=true

--- a/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json
+++ b/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://www.dojot.com.br/schemas/ch-owner-cert",
+  "$id": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json",
   "title": "Change ownership of a Certificate Schema",
   "description": "Schema for validating the input body of route for change the ownership of a certificate'.",
   "type": "object",
   "default": {},
   "properties": {
     "belongsTo": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/belongsTo"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo"
     }
   },
   "required": [

--- a/iam/x509-identity-mgmt/js/schemas/defs.json
+++ b/iam/x509-identity-mgmt/js/schemas/defs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://www.dojot.com.br/schemas/defs",
+  "$id": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json",
   "definitions": {
     "fingerprint": {
       "type": "string",

--- a/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json
+++ b/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://www.dojot.com.br/schemas/reg-or-gen-cert",
+  "$id": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json",
   "title": "Register or Generate x.509 Certificate Schema",
   "description": "Schema for validating the input body of route for register x.509 external certificate or generate one'.",
   "type": "object",
@@ -8,16 +8,16 @@
   "additionalProperties": false,
   "properties": {
     "caFingerprint": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/fingerprint"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/fingerprint"
     },
     "certificateChain": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/cert-pem"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem"
     },
     "csr": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/csr"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/csr"
     },
     "belongsTo": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/belongsTo"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo"
     }
   },
   "oneOf": [

--- a/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json
+++ b/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://www.dojot.com.br/schemas/reg-trust-ca",
+  "$id": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json",
   "title": "Register Trusted CA Schema",
   "description": "Schema for validating the input body of Route 'Register Trusted CA Certificate'.",
   "additionalProperties": false,
@@ -11,7 +11,7 @@
   ],
   "properties": {
     "caPem": {
-      "$ref": "http://www.dojot.com.br/schemas/defs#/definitions/cert-pem"
+      "$ref": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem"
     },
     "allowAutoRegistration": {
       "type": "boolean",

--- a/iam/x509-identity-mgmt/js/schemas/update-trusted-ca-certificate.json
+++ b/iam/x509-identity-mgmt/js/schemas/update-trusted-ca-certificate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://www.dojot.com.br/schemas/upd-trust-ca",
+  "$id": "https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/update-trusted-ca-certificate.json",
   "title": "Update Trusted CA Schema",
   "description": "Schema for validating the input body of Route 'Update Trusted CA Certificate'.",
   "additionalProperties": false,

--- a/iam/x509-identity-mgmt/js/src/DIContainer.js
+++ b/iam/x509-identity-mgmt/js/src/DIContainer.js
@@ -383,7 +383,9 @@ function createObject(config) {
     certificateService: asFunction(fromDecoratedClass(CertificateService), {
       injector: () => ({
         certValidity: config.certificate.validity,
-        checkPublicKey: config.certificate.checkpublickey,
+        checkPublicKey: config.certificate.check.publickey,
+        checkSubjectDN: config.certificate.check.subjectdn,
+        checkDeviceExists: config.certservice.check.device.exists,
         queryMaxTimeMS: config.mongo.query.maxtimems,
         certMinimumValidityDays: config.certificate.external.minimumvaliditydays,
         caCertAutoRegistration: config.certificate.external.ca.autoregistration,

--- a/iam/x509-identity-mgmt/js/src/deviceManager/DeviceMgrProvider.js
+++ b/iam/x509-identity-mgmt/js/src/deviceManager/DeviceMgrProvider.js
@@ -24,14 +24,14 @@ class DeviceMgrProvider {
   }
 
   /**
-   * Checks whether there is a relationship between the informed tenant and the device.
+   * Checks that the device exists for the tenant (if the device belongs to the tenant).
    *
    * @param {string} tenant
    * @param {string} deviceId
    *
-   * @return {boolean} True if the tenant owns the device, otherwise, false.
+   * @return {boolean} True if the device exists and belongs to the tenant, otherwise, false.
    */
-  async checkOwner(tenant, deviceId) {
+  async checkDeviceExists(tenant, deviceId) {
     const cacheHit = await this.deviceModel.contains(tenant, deviceId);
     if (cacheHit) {
       return true;
@@ -50,7 +50,7 @@ class DeviceMgrProvider {
       return true;
     }
 
-    // Device does not belong to the tenant
+    // device does not exist or does not belong to the tenant.
     return false;
   }
 

--- a/iam/x509-identity-mgmt/js/src/services/CertificateService.js
+++ b/iam/x509-identity-mgmt/js/src/services/CertificateService.js
@@ -269,11 +269,14 @@ class CertificateService {
       // eslint-disable-next-line default-case
       switch (determineNotificationType(previousBelongsTo, belongsTo)) {
         case 'creation':
-          await this.ownershipNotifier.creation(certRecord, belongsTo); break;
+          await this.ownershipNotifier.creation(certRecord, belongsTo);
+          break;
         case 'change':
-          await this.ownershipNotifier.change(certRecord, previousBelongsTo, belongsTo); break;
+          await this.ownershipNotifier.change(certRecord, previousBelongsTo, belongsTo);
+          break;
         case 'removal':
-          await this.ownershipNotifier.removal(certRecord, previousBelongsTo); break;
+          await this.ownershipNotifier.removal(certRecord, previousBelongsTo);
+          break;
       }
     }
   }

--- a/iam/x509-identity-mgmt/js/src/services/CertificateService.js
+++ b/iam/x509-identity-mgmt/js/src/services/CertificateService.js
@@ -54,8 +54,8 @@ class CertificateService {
    * The dependencies are injected through the constructor
    */
   constructor({
-    trustedCAService, certificateModel, ejbcaFacade, tenant, pkiUtils,
-    dnUtils, certValidity, checkPublicKey, queryMaxTimeMS, certMinimumValidityDays,
+    trustedCAService, certificateModel, ejbcaFacade, tenant, pkiUtils, dnUtils, certValidity,
+    checkPublicKey, checkSubjectDN, checkDeviceExists, queryMaxTimeMS, certMinimumValidityDays,
     caCertAutoRegistration, logger, errorTemplate, deviceMgrProvider, ownershipNotifier,
   }) {
     Object.defineProperty(this, 'trustedCAService', { value: trustedCAService });
@@ -65,6 +65,8 @@ class CertificateService {
     Object.defineProperty(this, 'dnUtils', { value: dnUtils });
     Object.defineProperty(this, 'certValidity', { value: certValidity });
     Object.defineProperty(this, 'checkPublicKey', { value: checkPublicKey });
+    Object.defineProperty(this, 'checkSubjectDN', { value: checkSubjectDN });
+    Object.defineProperty(this, 'checkDeviceExists', { value: checkDeviceExists });
     Object.defineProperty(this, 'queryMaxTimeMS', { value: queryMaxTimeMS });
     Object.defineProperty(this, 'certMinimumValidityDays', { value: certMinimumValidityDays });
     Object.defineProperty(this, 'caCertAutoRegistration', { value: caCertAutoRegistration });
@@ -89,15 +91,26 @@ class CertificateService {
       this.pkiUtils.checkPublicKey(csr.subjectPublicKeyInfo);
     }
 
-    const distinguishedNames = this.dnUtils.from(csr.subject, true).verify();
+    // extracts the SubjectDN fields from the CSR
+    const distinguishedNames = this.dnUtils.from(csr.subject, true);
 
-    // ensure that the current tenant owns the device
-    await this.ensureOwner(distinguishedNames.CN);
+    if (this.checkSubjectDN) {
+      // Performs checks on the Subject DN
+      distinguishedNames.verify();
+
+      // Since the device ID is expected to be reported via 'Common Name',
+      // it ensures that the device exists for the current tenant
+      await this.ensureDeviceExists(distinguishedNames.CN);
+
+      // Adds the tenant as a prefix to the SubjectDN 'Common Name' field
+      distinguishedNames.cnamePrefix(this.tenant);
+    }
+
+    // Converts SubjectDN fields to a string
+    const subjectDN = distinguishedNames.stringify();
 
     // Checks on the certificate owner
     await this.checkBelongsTo(belongsTo);
-
-    const subjectDN = distinguishedNames.cnamePrefix(this.tenant).stringify();
 
     const certificatePem = await this.ejbcaFacade.generateCertificate(
       subjectDN, this.certValidity, csrPem,
@@ -418,23 +431,26 @@ class CertificateService {
       throw this.error.BadRequest('The certificate must belong to only one type of owner.');
     }
 
-    // ensure that the current tenant owns the device
+    // If the certificate belongs to a device, it ensures
+    // that the device exists for the current tenant
     if (belongsTo.device) {
-      await this.ensureOwner(belongsTo.device);
+      await this.ensureDeviceExists(belongsTo.device);
     }
   }
 
   /**
-   * Ensures that the current tenant owns the device.
+   * Ensures that the device exists and belongs to the current tenant.
    *
    * @param {string} deviceId Device identifier
    *
    * @throws an exception if no relationship is found between the device identifier and the tenant.
    */
-  async ensureOwner(deviceId) {
-    const isOwner = await this.deviceMgrProvider.checkOwner(this.tenant, deviceId);
-    if (!isOwner) {
-      throw this.error.BadRequest(`Device identifier '${deviceId}' was not found for tenant '${this.tenant}'.`);
+  async ensureDeviceExists(deviceId) {
+    if (this.checkDeviceExists) {
+      const isOwner = await this.deviceMgrProvider.checkDeviceExists(this.tenant, deviceId);
+      if (!isOwner) {
+        throw this.error.BadRequest(`Device identifier '${deviceId}' was not found for tenant '${this.tenant}'.`);
+      }
     }
   }
 }

--- a/iam/x509-identity-mgmt/js/src/services/TrustedCAService.js
+++ b/iam/x509-identity-mgmt/js/src/services/TrustedCAService.js
@@ -93,8 +93,7 @@ class TrustedCAService {
       },
     }).exec();
 
-    const bundle = result.map((el) => el.caPem);
-    return bundle;
+    return result.map((el) => el.caPem);
   }
 
   /**

--- a/iam/x509-identity-mgmt/js/tests/json-schema/certificates.test.js
+++ b/iam/x509-identity-mgmt/js/tests/json-schema/certificates.test.js
@@ -35,7 +35,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'required',
@@ -80,7 +80,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'not',
@@ -127,26 +127,26 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'not',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/dependencies/device/not',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/dependencies/device/not',
                 params: {},
                 message: 'should NOT be valid',
               },
               {
                 keyword: 'not',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/dependencies/application/not',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/dependencies/application/not',
                 params: {},
                 message: 'should NOT be valid',
               },
               {
                 keyword: 'oneOf',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/oneOf',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/oneOf',
                 params: {
                   passingSchemas: [
                     0,
@@ -173,12 +173,12 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.certificateChain',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/type',
                 params: {
                   type: 'string',
                 },
@@ -199,12 +199,12 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.csr',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/csr/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/csr/type',
                 params: {
                   type: 'string',
                 },
@@ -228,12 +228,12 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.belongsTo.device',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/device/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/type',
                 params: {
                   type: 'string,null',
                 },
@@ -257,12 +257,12 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/type',
                 params: {
                   type: 'string,null',
                 },
@@ -271,7 +271,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
               {
                 keyword: 'enum',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/enum',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/enum',
                 params: {
                   allowedValues: [
                     'kafka-consumer',
@@ -300,7 +300,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [{
               dataPath: '.certificateChain',
               keyword: 'maxLength',
@@ -308,7 +308,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
               params: {
                 limit: 65536,
               },
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/maxLength',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/maxLength',
             }],
           },
         });
@@ -324,7 +324,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [{
               dataPath: '.csr',
               keyword: 'maxLength',
@@ -332,7 +332,7 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
               params: {
                 limit: 65536,
               },
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/csr/maxLength',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/csr/maxLength',
             }],
           },
         });
@@ -351,11 +351,11 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [{
               keyword: 'pattern',
               dataPath: '.certificateChain',
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/pattern',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/pattern',
               params: {
                 pattern: '^(-{5}BEGIN CERTIFICATE-{5}(\\r\\n|\\r|\\n)([-A-Za-z0-9+/=]{1,64}(\\r\\n|\\r|\\n))+-{5}END CERTIFICATE-{5}(\\r\\n|\\r|\\n)?)+$',
               },
@@ -375,11 +375,11 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [{
               keyword: 'pattern',
               dataPath: '.csr',
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/csr/pattern',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/csr/pattern',
               params: {
                 pattern: '^-{5}BEGIN CERTIFICATE REQUEST-{5}(\\r\\n|\\r|\\n)([-A-Za-z0-9+/=]{1,64}(\\r\\n|\\r|\\n))+-{5}END CERTIFICATE REQUEST-{5}(\\r\\n|\\r|\\n)?$',
               },
@@ -402,11 +402,11 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-or-gen-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-or-generate-certificate.json',
             schemaErrors: [{
               keyword: 'pattern',
               dataPath: '.belongsTo.device',
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/device/pattern',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/pattern',
               params: {
                 pattern: '^[0-9a-fA-F-]{6,36}$',
               },
@@ -429,7 +429,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [{
               keyword: 'required',
               dataPath: '',
@@ -456,26 +456,26 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [
               {
                 keyword: 'not',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/dependencies/device/not',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/dependencies/device/not',
                 params: {},
                 message: 'should NOT be valid',
               },
               {
                 keyword: 'not',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/dependencies/application/not',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/dependencies/application/not',
                 params: {},
                 message: 'should NOT be valid',
               },
               {
                 keyword: 'type',
                 dataPath: '.belongsTo.device',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/device/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/type',
                 params: {
                   type: 'string,null',
                 },
@@ -484,7 +484,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               {
                 keyword: 'type',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/type',
                 params: {
                   type: 'string,null',
                 },
@@ -493,7 +493,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               {
                 keyword: 'enum',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/enum',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/enum',
                 params: {
                   allowedValues: [
                     'kafka-consumer',
@@ -507,7 +507,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               {
                 keyword: 'oneOf',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/oneOf',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/oneOf',
                 params: {
                   passingSchemas: [
                     0,
@@ -534,12 +534,12 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/type',
                 params: {
                   type: 'object',
                 },
@@ -548,7 +548,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               {
                 keyword: 'oneOf',
                 dataPath: '.belongsTo',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/oneOf',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/oneOf',
                 params: {
                   passingSchemas: [
                     0,
@@ -574,11 +574,11 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [{
               keyword: 'type',
               dataPath: '.belongsTo.device',
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/device/type',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/type',
               params: {
                 type: 'string,null',
               },
@@ -600,12 +600,12 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/type',
                 params: {
                   type: 'string,null',
                 },
@@ -614,7 +614,7 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               {
                 keyword: 'enum',
                 dataPath: '.belongsTo.application',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/application/enum',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/application/enum',
                 params: {
                   allowedValues: [
                     'kafka-consumer',
@@ -645,11 +645,11 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/ch-owner-cert',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/change-owner-certificate.json',
             schemaErrors: [{
               keyword: 'pattern',
               dataPath: '.belongsTo.device',
-              schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/belongsTo/properties/device/pattern',
+              schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/pattern',
               params: {
                 pattern: '^[0-9a-fA-F-]{6,36}$',
               },

--- a/iam/x509-identity-mgmt/js/tests/json-schema/trustedCAs.test.js
+++ b/iam/x509-identity-mgmt/js/tests/json-schema/trustedCAs.test.js
@@ -31,7 +31,7 @@ describe('Trusted CAs - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 keyword: 'required',
@@ -61,12 +61,12 @@ describe('Trusted CAs - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',
                 dataPath: '.caPem',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/type',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/type',
                 params: {
                   type: 'string',
                 },
@@ -99,7 +99,7 @@ describe('Trusted CAs - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 dataPath: '.caPem',
@@ -108,7 +108,7 @@ describe('Trusted CAs - JSON Schema validations [on http POST]', () => {
                 params: {
                   limit: 65536,
                 },
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/maxLength',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/maxLength',
 
               },
             ],
@@ -129,12 +129,12 @@ describe('Trusted CAs - JSON Schema validations [on http POST]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/reg-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/register-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 keyword: 'pattern',
                 dataPath: '.caPem',
-                schemaPath: 'http://www.dojot.com.br/schemas/defs#/definitions/cert-pem/pattern',
+                schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/cert-pem/pattern',
                 params: {
                   pattern: '^(-{5}BEGIN CERTIFICATE-{5}(\\r\\n|\\r|\\n)([-A-Za-z0-9+/=]{1,64}(\\r\\n|\\r|\\n))+-{5}END CERTIFICATE-{5}(\\r\\n|\\r|\\n)?)+$',
                 },
@@ -158,7 +158,7 @@ describe('Trusted CAs - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/upd-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/update-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 keyword: 'required',
@@ -187,7 +187,7 @@ describe('Trusted CAs - JSON Schema validations [on http PATCH]', () => {
         expect(res.body).toEqual({
           error: 'Input data schema validation failure.',
           detail: {
-            schemaId: 'http://www.dojot.com.br/schemas/upd-trust-ca',
+            schemaId: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/update-trusted-ca-certificate.json',
             schemaErrors: [
               {
                 keyword: 'type',

--- a/iam/x509-identity-mgmt/js/tests/unitary/deviceManager/DeviceMgrProvider.test.js
+++ b/iam/x509-identity-mgmt/js/tests/unitary/deviceManager/DeviceMgrProvider.test.js
@@ -63,7 +63,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
       return request;
     });
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).resolves.toBeTruthy();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).resolves.toBeTruthy();
 
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(1);
@@ -72,7 +72,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
   it('should check that the device belongs to the tenant (via the cache)', async () => {
     deviceMgrProvider.deviceModel.contains = jest.fn().mockResolvedValue(true);
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).resolves.toBeTruthy();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).resolves.toBeTruthy();
 
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(0);
@@ -87,7 +87,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
       return request;
     });
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).resolves.toBeFalsy();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).resolves.toBeFalsy();
 
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(0);
@@ -102,7 +102,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
       return request;
     });
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).rejects.toThrow();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).rejects.toThrow();
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(0);
   });
@@ -122,7 +122,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
       };
     });
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).rejects.toThrow();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).rejects.toThrow();
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(0);
   });
@@ -144,7 +144,7 @@ describe("Unit tests of script 'DeviceMgrProvider.js'", () => {
       return requestAlt;
     });
 
-    await expect(deviceMgrProvider.checkOwner('admin', 'abc123')).rejects.toThrow();
+    await expect(deviceMgrProvider.checkDeviceExists('admin', 'abc123')).rejects.toThrow();
     expect(deviceMgrProvider.deviceModel.contains).toHaveBeenCalledTimes(1);
     expect(deviceMgrProvider.deviceModel.insert).toHaveBeenCalledTimes(0);
     expect(requestAlt.abort).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The service always performed validations on the SubjectDN of the informed CSR to obtain a certificate signed by the platform.
These validations forced the user to set on the SubjectDN `Common Name` an existing and valid device ID for the current tenant.

* **What is the new behavior (if this is a feature change)?**

As the association of devices with certificates is no longer done by the `Common Name` due to the support for external certificates, these checks were disabled by default.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It depends on the change of the IoTAgent to use the certificate fingerprint to recognize the associated device.

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#1540

* **Other information**:

SubjectDN validation can be reactivated through an environment variable, but this behavior is not necessary when the IoT Agent relies on the certificate's fingerprint to discover the associated device.

A flag was added in the validation if the device ID really exists for the current tenant. By default, this flag remains enabled.
If it is disabled, the user will be able to enter any value as a device identifier, even so (s)he will not be able to impersonate other tenants' devices, (s)he just won't be able to use the certificate until enter a valid device ID for her/his tenant.