### PR TITLE
[cert-sidecar] Obtaining the CA bundle file

### DIFF
--- a/tools/cert-sidecar/README.md
+++ b/tools/cert-sidecar/README.md
@@ -43,7 +43,7 @@ In the end, we can say that **Cert-Sidecar** creates four files in the *PEM* for
 
 __ATTENTION__ When the service is unable to retrieve a CRL or update certificates if they have been revoked or expired (if these settings are active), after several defined attempts using the Exponential Backoff strategy the service will terminate and delete all files (if deletions are enabled). And at each configured time, the service checks if it can connect with *x509-identity-mgmt* and if it does not, the service changes to unhealthy. For more information about that, check the [__Service State Manager__ ](https://github.com/dojot/dojot-microservice-sdk-js/blob/master/lib/serviceStateManager/README.md) module in our [Microservice SDK](https://github.com/dojot/dojot-microservice-sdk-js).
 
-__ATTENTION__  It's important to note that in services that use Node.js and [TLS module](https://nodejs.org/api/tls.html#tls_tls_ssl), the certificates, including the crl, are not changed automatically after the service starts even if the files are updated. The [`server.setSecureContext()`](https://nodejs.org/api/tls.html#tls_server_setsecurecontext_options) method can be used for this purpose, available from version 11 of Node.js. 
+__ATTENTION__  It's important to note that in services that use Node.js and [TLS module](https://nodejs.org/api/tls.html#tls_tls_ssl), the certificates, including the crl, are not changed automatically after the service starts even if the files are updated. The [`server.setSecureContext()`](https://nodejs.org/api/tls.html#tls_server_setsecurecontext_options) method can be used for this purpose, available from version 11 of Node.js.
 
 There is a examples of how to use  **Cert-Sidecar** with kubernetes and docker-compose within the directory [examples](./examples).
 
@@ -119,7 +119,7 @@ Cron configurations
 | cron.expiration.time |  Cron patterns for checking expiration. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */1 * * *` | string | CERT_SC_CRON_EXPIRATION_TIME
 | cron.revoke | Enables the use of *cron* for checking if the  Public Certificate is revoked. This needs `certs.crl` to be true. Note: *x509 identity mgmt*  is not yet supported for revoking internal certificates | false | boolean | CERT_SC_CRON_REVOKE
 | cron.revoke.time |  Cron patterns for checking revoking. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */3 * * *` | string | CERT_SC_CRON_REVOKE_TIME
-| cron.cabundle | Enables the use of *cron* for update the CA certificates Bundle (TrustStore) | true | boolean | CERT_SC_CRON_CABUNDLE
+| cron.cabundle | Enables the use of *cron* for update the CA certificates Bundle (TrustStore) | false | boolean | CERT_SC_CRON_CABUNDLE
 | cron.cabundle.time |  Cron patterns for update the CA certificates Bundle. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */1 * * *` | string | CERT_SC_CRON_CABUNDLE_TIME
 
 

--- a/tools/cert-sidecar/README.md
+++ b/tools/cert-sidecar/README.md
@@ -6,19 +6,21 @@ __NOTE THAT__ In Kubernetes, a pod is a group of one or more containers with sha
 
 ## **Table of Contents**
 
-1. [Overview](#overview)
-2. [Dependencies](#dependencies)
-   1. [Dojot Services](#dojot-services)
-3. [Running the service](#running-the-service)
-   1. [Configuration](#configuration)
-      1. [General](#general)
-      2. [Certificates](#certificates)
-      3. [Cron](#cron)
-      4. [x509 identity mgmt](#x509-identity-mgmt)
-      5. [Service State Manager](#service-state-manager)
-   2. [How to run](#how-to-run)
-4. [Documentation](#documentation)
-5. [Issues and help](#issues-and-help)
+- [**Cert-Sidecar**](#cert-sidecar)
+  - [**Table of Contents**](#table-of-contents)
+  - [**Overview**](#overview)
+  - [Dependencies](#dependencies)
+    - [Dojot Services](#dojot-services)
+  - [Running the service](#running-the-service)
+    - [Configuration](#configuration)
+      - [General](#general)
+      - [Certificates](#certificates)
+      - [Cron](#cron)
+      - [x509 identity mgmt](#x509-identity-mgmt)
+      - [Service State Manager](#service-state-manager)
+  - [How to run](#how-to-run)
+  - [Documentation](#documentation)
+  - [Issues and help](#issues-and-help)
 
 ## **Overview**
 
@@ -100,6 +102,7 @@ Certificates configurations
 | certs.crl | Enables the use of CRL (obtaining and creating the file)  | false | boolean | CERT_SC_CERTS_CRL
 | certs.files.basepath | Path to create files  | /certs | path | CERT_SC_CERTS_FILES_BASEPATH
 | certs.files.ca |  CA root certificate filename | ca.pem | filename  | CERT_SC_CERTS_FILES_CA
+| certs.files.cabundle |  CA certificates Bundle (TrustStore) filename | cabundle.pem | filename  | CERT_SC_CERTS_FILES_CABUNDLE
 | certs.files.cert | Public certificate filename | cert.pem | filename  | CERT_SC_CERTS_FILES_CERT
 | certs.files.crl | CRL filename  | crl.pem | filename | CERT_SC_CERTS_FILES_CRL
 | certs.files.key | Private keys filename | key.pem | filename | CERT_SC_CERTS_FILES_KEY
@@ -111,11 +114,14 @@ Cron configurations
 | Key | Purpose | Default Value | Valid Values | Environment variable
 | --- | ------- | ------------- | ------------ | --------------------
 | cron.crl | Enables the use of *cron* for updating CRL. | true | boolean | CERT_SC_CRON_CRL
-| cron.crl.time | Cron patterns for updating CRL. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | 0 * */2 * * * | string | CERT_SC_CRON_CRL_TIME
+| cron.crl.time | Cron patterns for updating CRL. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */2 * * *` | string | CERT_SC_CRON_CRL_TIME
 | cron.expiration | Enables the use of *cron* for checking expiration for Public Certificate and Public CA certificate.  | true | boolean | CERT_SC_CRON_EXPIRATION
-| cron.expiration.time |  Cron patterns for checking expiration. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | 0 * */1 * * * | string | CERT_SC_CRON_EXPIRATION_TIME
+| cron.expiration.time |  Cron patterns for checking expiration. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */1 * * *` | string | CERT_SC_CRON_EXPIRATION_TIME
 | cron.revoke | Enables the use of *cron* for checking if the  Public Certificate is revoked. This needs `certs.crl` to be true. Note: *x509 identity mgmt*  is not yet supported for revoking internal certificates | false | boolean | CERT_SC_CRON_REVOKE
-| cron.revoke.time |  Cron patterns for checking revoking. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | 0 * */3 * * * | string | CERT_SC_CRON_REVOKE_TIME
+| cron.revoke.time |  Cron patterns for checking revoking. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */3 * * *` | string | CERT_SC_CRON_REVOKE_TIME
+| cron.cabundle | Enables the use of *cron* for update the CA certificates Bundle (TrustStore) | true | boolean | CERT_SC_CRON_CABUNDLE
+| cron.cabundle.time |  Cron patterns for update the CA certificates Bundle. [Read up on cron patterns](https://www.npmjs.com/package/cron#available-cron-patterns) | `0 * */1 * * *` | string | CERT_SC_CRON_CABUNDLE_TIME
+
 
 #### x509 identity mgmt
 
@@ -128,6 +134,7 @@ X509 identity mgmt configurations
 | x509.path.sign | Resource to sign the csr, create a public certificate.  | /internal/api/v1/throw-away | string | CERT_SC_X509_PATH_SIGN
 | x509.path.crl | Resource to retrieve the latest CRL released by the root CA. | /internal/api/v1/throw-away/ca/crl | string | CERT_SC_X509_PATH_CRL
 | x509.path.ca | Resource to retrieve the root CA of the dojot platform | /internal/api/v1/throw-away/ca | string | CERT_SC_X509_PATH_CA
+| x509.path.cabundle | Resource to retrieve the root CA of the dojot platform and all the external trusted CAs | /internal/api/v1/throw-away/ca/bundle | string | CERT_SC_X509_PATH_CABUNDLE
 | x509.retries | Number of retries when using *x509 identity mgmt*  before service shutdown. The strategy used is described in [Exponential Backoff](https://developers.google.com/analytics/devguides/reporting/core/v3/errors#backoff) | 9 | integer | CERT_SC_X509_RETRIES
 | x509.timeout.ms | Specifies the number of milliseconds before the request times out. If the request takes longer than `timeout`, the request will be aborted. | 1000 | integer | CERT_SC_X509_TIMEOUT
 

--- a/tools/cert-sidecar/app/App.js
+++ b/tools/cert-sidecar/app/App.js
@@ -47,6 +47,8 @@ class App {
       .certsWillExpire.bind(this.certMgmt.getCertificates());
     const boundRetrieveCRL = this.certMgmt.getCertificates()
       .retrieveCRL.bind(this.certMgmt.getCertificates());
+    const boundRetrieveCaBundle = this.certMgmt.getCertificates()
+      .retrieveCaBundle.bind(this.certMgmt.getCertificates());
 
     let errorHandleShutdown = null;
     if (configApp.shutdown) {
@@ -59,6 +61,7 @@ class App {
       boundRetrieveCRL,
       boundCertWillExpire,
       boundCertHasRevoked,
+      boundRetrieveCaBundle,
       errorHandleShutdown,
     );
   }

--- a/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
+++ b/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
@@ -23,6 +23,7 @@ class Certificates {
  * @param {Object} paths
  * @param {String} paths.crl Path to crl
  * @param {String} paths.ca  Path to ca
+ * @param {String} paths.caBundle  Path to ca bundle
  * @param {String} paths.cert  Path to certificate
  * @param {String} paths.key Path to privatekey
  */
@@ -67,6 +68,11 @@ class Certificates {
      */
     this.pathCA = paths.ca;
     /**
+     *  Path to ca bundle
+     * @type {String}
+     */
+    this.pathCABundle = paths.caBundle;
+    /**
      *  Path to certificate
      * @type {String}
      */
@@ -82,7 +88,7 @@ class Certificates {
   }
 
   /**
-   * Delete the files of the certificates of crl, ca, cert and key
+   * Delete the files of the certificates of crl, ca, ca_bundle, cert and key
    */
   async deleteAllFiles() {
     // Checks whether file deletion is active
@@ -95,6 +101,7 @@ class Certificates {
         }
 
         await deleteFile(this.pathCA);
+        await deleteFile(this.pathCABundle);
         await deleteFile(this.pathCert);
         await deleteFile(this.pathKey);
 
@@ -272,6 +279,22 @@ class Certificates {
       throw e;
     }
     this.logger.info('retrieveCaCert: ... ending retrieve a CA Certificate...');
+  }
+
+  /**
+   * Retrieve CA certificate bundle and create a new file in 'certs.files.cabundle'
+   */
+  async retrieveCaBundle() {
+    this.logger.info('retrieveCaBundle: Retrieving  a CA Certificate Bundle...');
+    try {
+      const caBundle = await this.x509IdentityMgmt.getRequests().getCACertBundle();
+      this.caBundle = caBundle;
+      await createFile(this.pathCABundle, this.caBundle);
+    } catch (e) {
+      this.logger.error('retrieveCaBundle:', e);
+      throw e;
+    }
+    this.logger.info('retrieveCaBundle: ... ending retrieve a CA Certificate Bundle...');
   }
 }
 

--- a/tools/cert-sidecar/app/certificatesMgmt/index.js
+++ b/tools/cert-sidecar/app/certificatesMgmt/index.js
@@ -29,6 +29,7 @@ class CertificatesMgmt {
     const filenameInCertFolder = (filename) => (createFilename(filename, configCerts['files.basepath']));
     const paths = {
       ca: filenameInCertFolder(configCerts['files.ca']),
+      caBundle: filenameInCertFolder(configCerts['files.cabundle']),
       crl: filenameInCertFolder(configCerts['files.crl']),
       cert: filenameInCertFolder(configCerts['files.cert']),
       key: filenameInCertFolder(configCerts['files.key']),
@@ -63,6 +64,10 @@ class CertificatesMgmt {
       this.logger.debug('Init: Calling retrieveCaCert...');
       await this.certificates.retrieveCaCert();
       this.logger.debug('Init: ...retrieveCaCert called.');
+
+      this.logger.debug('Init: Calling retrieveCaBundle...');
+      await this.certificates.retrieveCaBundle();
+      this.logger.debug('Init: ...retrieveCaBundle called.');
 
       this.logger.debug('Init: Calling retrieveCRL...');
       // checks if crl is enabled

--- a/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
+++ b/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
@@ -6,6 +6,13 @@ const {
   app: configApp,
 } = ConfigManager.getConfig('CERT_SC');
 
+const axiosCfg = {
+  headers: {
+    Accept: 'application/x-pem-file',
+  },
+  responseType: 'text',
+};
+
 /**
  * This class call X509IdentityMgmt api to sign a csr,
  * retrieve ca certificate and crl
@@ -56,12 +63,10 @@ class Requests {
         status,
         statusText,
         data,
-      } = await this.axiosX509.post(
-        this.paths.sign,
-        { csr },
-      );
+      } = await this.axiosX509.post(this.paths.sign, { csr }, axiosCfg);
+
       if (status === 201) {
-        return data.certificatePem;
+        return data;
       }
 
       this.logger.warn('Cannot create a certificate from CSR.  '
@@ -88,11 +93,10 @@ class Requests {
         status,
         statusText,
         data,
-      } = await this.axiosX509.get(
-        this.paths.crl,
-      );
+      } = await this.axiosX509.get(this.paths.crl, axiosCfg);
+
       if (status === 200) {
-        return data.crl;
+        return data;
       }
 
       this.logger.warn('getCRL: Cannot retrieve CRL.  '
@@ -118,12 +122,10 @@ class Requests {
         status,
         statusText,
         data,
-      } = await this.axiosX509.get(
-        this.paths.ca,
-      );
+      } = await this.axiosX509.get(this.paths.ca, axiosCfg);
 
       if (status === 200) {
-        return data.caPem;
+        return data;
       }
 
       this.logger.warn('getCACert: Cannot retrieve CA certificate.  '
@@ -151,12 +153,7 @@ class Requests {
         status,
         statusText,
         data,
-      } = await this.axiosX509.get(this.paths.caBundle, {
-        headers: {
-          Accept: 'application/x-pem-file',
-        },
-        responseType: 'text',
-      });
+      } = await this.axiosX509.get(this.paths.caBundle, axiosCfg);
 
       if (status === 200) {
         return data;

--- a/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
+++ b/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
@@ -20,6 +20,7 @@ class Requests {
    * @param {*} paths.sign
    * @param {*} paths.crl
    * @param {*} paths.ca
+   * @param {*} paths.caBundle
    */
   constructor(url,
     timeout,
@@ -111,7 +112,7 @@ class Requests {
    * @returns {String|null} PEM encoded Certificate
    */
   async getCACertificate() {
-    this.logger.debug('createCert: Getting the CA certificate...');
+    this.logger.debug('getCACert: Getting the CA certificate...');
     try {
       const {
         status,
@@ -131,6 +132,42 @@ class Requests {
     } catch (error) {
       this.logger.error('getCACert:', error);
       throw new Error('Cannot retrieve CA certificate');
+    }
+  }
+
+  /**
+   * Obtains a CA's certificate bundle trusted by the platform.
+   * The first certificate in the bundle is that of the platform's CA,
+   * the rest are external CAs that have been registered as trusted.
+   *
+   * @throws Will throw an error if cannot retrieve  CA certificate
+   *
+   * @returns {String|null} PEM encoded Certificate
+   */
+  async getCACertBundle() {
+    this.logger.debug("getCABundle: Getting the trusted CA's certificate bundle...");
+    try {
+      const {
+        status,
+        statusText,
+        data,
+      } = await this.axiosX509.get(this.paths.caBundle, {
+        headers: {
+          Accept: 'application/x-pem-file',
+        },
+        responseType: 'text',
+      });
+
+      if (status === 200) {
+        return data;
+      }
+
+      this.logger.warn("getCABundle: Cannot retrieve the trusted CA's certificate bundle. "
+        + `The API returns: code=${status}; message=${statusText}`);
+      return null;
+    } catch (error) {
+      this.logger.error('getCABundle:', error);
+      throw new Error('Cannot retrieve CA certificate bundle');
     }
   }
 }

--- a/tools/cert-sidecar/app/x509IdentityMgmt/index.js
+++ b/tools/cert-sidecar/app/x509IdentityMgmt/index.js
@@ -28,6 +28,7 @@ class X509IdentityMgmt {
         sign: configX509['path.sign'],
         crl: configX509['path.crl'],
         ca: configX509['path.ca'],
+        caBundle: configX509['path.cabundle'],
       },
     );
     this.logger = new Logger(`cert-sc-${configApp['sidecar.to']}:x509IdentityMgmt`);

--- a/tools/cert-sidecar/config/default.conf
+++ b/tools/cert-sidecar/config/default.conf
@@ -4,6 +4,7 @@ x509.url:string=http://x509-identity-mgmt:3000
 x509.path.sign:string=/internal/api/v1/throw-away
 x509.path.crl:string=/internal/api/v1/throw-away/ca/crl
 x509.path.ca:string=/internal/api/v1/throw-away/ca
+x509.path.cabundle:string=/internal/api/v1/throw-away/ca/bundle
 x509.retries:integer=9
 x509.timeout.ms:integer=1000
 x509.healthchecker.ms:integer=60000
@@ -41,6 +42,10 @@ cron.expiration.time:string=0 * */1 * * *
 cron.revoke:boolean=false
 #every 3 hours
 cron.revoke.time:string=0 * */3 * * *
+# updates the file of trusted CAs
+cron.cabundle:boolean=true
+#every hour
+cron.cabundle.time:string=0 * */1 * * *
 
 
 #Certificates config
@@ -51,5 +56,6 @@ certs.crl:boolean=true
 certs.files.basepath:string=/certs
 certs.files.crl:string=crl.pem
 certs.files.ca:string=ca.pem
+certs.files.cabundle:string=cabundle.pem
 certs.files.cert:string=cert.pem
 certs.files.key:string=key.pem

--- a/tools/cert-sidecar/config/default.conf
+++ b/tools/cert-sidecar/config/default.conf
@@ -43,7 +43,7 @@ cron.revoke:boolean=false
 #every 3 hours
 cron.revoke.time:string=0 * */3 * * *
 # updates the file of trusted CAs
-cron.cabundle:boolean=true
+cron.cabundle:boolean=false
 #every hour
 cron.cabundle.time:string=0 * */1 * * *
 

--- a/tools/cert-sidecar/config/development.conf
+++ b/tools/cert-sidecar/config/development.conf
@@ -16,6 +16,9 @@ cron.expiration.time=0 */1 * * * *
 cron.revoke=true
 #every minute
 cron.revoke.time=0 */1 * * * *
+cron.cabundle=true
+#every minute
+cron.cabundle.time=0 */1 * * * *
 
 delete.certificates=true
 shutdown=true

--- a/tools/cert-sidecar/package-lock.json
+++ b/tools/cert-sidecar/package-lock.json
@@ -437,9 +437,9 @@
       }
     },
     "@dojot/microservice-sdk": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@dojot/microservice-sdk/-/microservice-sdk-0.1.9.tgz",
-      "integrity": "sha512-D5ks0edvlEQ0oBYPvAjFe2ukygNdWqpjmq1/GQ85Cp5yrUaHNWGa1UEZck87zvyTmmCu4+r10stxeOg8VQ2vvw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@dojot/microservice-sdk/-/microservice-sdk-0.1.11.tgz",
+      "integrity": "sha512-HpNH4DOnkGvdGaWbTCzRuIBRwSVEDe2+WEvkExBKY7A9UeHRVCZSO/DwoZccSb69xB1iSrvZJXNbdRznvFecnA==",
       "requires": {
         "async": "^3.1.0",
         "compression": "^1.7.4",
@@ -451,6 +451,8 @@
         "fast-safe-stringify": "^2.0.7",
         "flat": "^5.0.0",
         "http-errors": "^1.8.0",
+        "jsonwebtoken": "^8.5.1",
+        "jwt-decode": "^3.1.2",
         "lightship": "^6.2.1",
         "lodash": "^4.17.19",
         "morgan": "^1.10.0",
@@ -1988,6 +1990,11 @@
             "node-int64": "^0.4.0"
           }
         },
+        "buffer-equal-constant-time": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
         "buffer-from": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2517,6 +2524,14 @@
           "requires": {
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.1.0"
+          }
+        },
+        "ecdsa-sig-formatter": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+          "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
           }
         },
         "ee-first": {
@@ -5308,6 +5323,35 @@
             "minimist": "^1.2.5"
           }
         },
+        "jsonwebtoken": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+          "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash.includes": "^4.3.0",
+            "lodash.isboolean": "^3.0.3",
+            "lodash.isinteger": "^4.0.4",
+            "lodash.isnumber": "^3.0.3",
+            "lodash.isplainobject": "^4.0.6",
+            "lodash.isstring": "^4.0.1",
+            "lodash.once": "^4.0.0",
+            "ms": "^2.1.1",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            },
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
         "jsprim": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5318,6 +5362,30 @@
             "json-schema": "0.2.3",
             "verror": "1.10.0"
           }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jwt-decode": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+          "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
         },
         "kind-of": {
           "version": "6.0.3",
@@ -5464,10 +5532,45 @@
           "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
           "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
         },
+        "lodash.includes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+        },
+        "lodash.isboolean": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+          "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+        },
+        "lodash.isinteger": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+          "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
         "lodash.isobject": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
           "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+          "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+          "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "lodash.once": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lodash.sortby": {
           "version": "4.7.0",

--- a/tools/cert-sidecar/package-lock.json
+++ b/tools/cert-sidecar/package-lock.json
@@ -8657,11 +8657,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "axios-retry": {
@@ -9392,14 +9392,6 @@
         "abab": "^2.0.3",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
       }
     },
     "debuglog": {
@@ -10354,12 +10346,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      }
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -10833,9 +10822,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "ip-regex": {
@@ -12280,7 +12269,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/tools/cert-sidecar/package.json
+++ b/tools/cert-sidecar/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@dojot/microservice-sdk": "0.1.9",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
     "cron": "^1.8.2",
     "lodash.camelcase": "^4.3.0",

--- a/tools/cert-sidecar/package.json
+++ b/tools/cert-sidecar/package.json
@@ -43,7 +43,7 @@
     }
   ],
   "dependencies": {
-    "@dojot/microservice-sdk": "0.1.9",
+    "@dojot/microservice-sdk": "0.1.11",
     "axios": "^0.21.1",
     "axios-retry": "^3.1.9",
     "cron": "^1.8.2",

--- a/tools/cert-sidecar/test/integration/X509IdentityMgmt.test.js
+++ b/tools/cert-sidecar/test/integration/X509IdentityMgmt.test.js
@@ -171,6 +171,38 @@ describe('x509Req.getRequests().getRequests().', () => {
     }
   });
 
+  test('getCACertBundle: ok', async () => {
+    mockAxiosGet.mockResolvedValueOnce({
+      status: 200,
+      data: 'ca bundle',
+    });
+    const bundle = await x509Req.getRequests().getCACertBundle();
+
+    expect(mockAxiosGet).toHaveBeenCalled();
+    expect(bundle).toBe('ca bundle');
+  });
+
+  test('getCACertBundle: error 400', async () => {
+    mockAxiosGet.mockResolvedValueOnce({
+      status: 400,
+    });
+    const bundle = await x509Req.getRequests().getCACertBundle();
+
+    expect(mockAxiosGet).toHaveBeenCalled();
+    expect(bundle).toBe(null);
+  });
+
+  test('getCACertBundle: reject', async () => {
+    expect.assertions(2);
+    mockAxiosGet.mockRejectedValueOnce(new Error());
+    try {
+      await x509Req.getRequests().getCACertBundle();
+    } catch (e) {
+      expect(mockAxiosGet).toHaveBeenCalled();
+      expect(e.message).toBe('Cannot retrieve CA certificate bundle');
+    }
+  });
+
   test('createInfluxHealthChecker - heath', async () => {
     x509Req.createHealthChecker();
 

--- a/tools/cert-sidecar/test/integration/X509IdentityMgmt.test.js
+++ b/tools/cert-sidecar/test/integration/X509IdentityMgmt.test.js
@@ -71,9 +71,7 @@ describe('x509Req.getRequests().getRequests().', () => {
   test('createCertificateByCSR: ok', async () => {
     mockAxiosPost.mockResolvedValueOnce({
       status: 201,
-      data: {
-        certificatePem: 'CERT',
-      },
+      data: 'CERT',
     });
     const newCert = await x509Req.getRequests().createCertificateByCSR('CSR');
 
@@ -106,9 +104,7 @@ describe('x509Req.getRequests().getRequests().', () => {
   test('getCRL: ok', async () => {
     mockAxiosGet.mockResolvedValueOnce({
       status: 200,
-      data: {
-        crl: 'CRL',
-      },
+      data: 'CRL',
     });
     const newCRL = await x509Req.getRequests().getCRL();
 
@@ -140,9 +136,7 @@ describe('x509Req.getRequests().getRequests().', () => {
   test('getCACertificate: ok', async () => {
     mockAxiosGet.mockResolvedValueOnce({
       status: 200,
-      data: {
-        caPem: 'CA',
-      },
+      data: 'CA',
     });
     const newCRL = await x509Req.getRequests().getCACertificate();
 

--- a/tools/cert-sidecar/test/unit/App.test.js
+++ b/tools/cert-sidecar/test/unit/App.test.js
@@ -37,6 +37,7 @@ const mockCertificatesMgmt = jest.fn().mockImplementation(() => ({
     certHasRevoked: jest.fn(),
     certsWillExpire: jest.fn(),
     retrieveCRL: jest.fn(),
+    retrieveCaBundle: jest.fn(),
     deleteAllFiles: jest.fn(),
   })),
 }));


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The `cert-side` service only retrieves the root CA certificate from the dojot platform. 
It does not retrieve certificates from external CAs trusted by the platform.

* **What is the new behavior (if this is a feature change)?**

The `cert-side` service starts to retrieve the bundle of CAs trusted by the platform, this bundle also contains the CA certificate from dojot, thus, the functionality of retrieving only the platform CA certificate becomes unnecessary when supporting external certificates. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, just add a new feature.

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#1940

* **Other information**:

Instead of using the dojot CA certificate file, the CAs Bundle file should be used by IoT Agents when dojot is configured to support devices with external certificates.