### PR TITLE
[x509-identity-mgmt] Support for content negotiation on internal endpoints

### DIFF
--- a/iam/x509-identity-mgmt/js/src/express/routes/contentNegotiation.js
+++ b/iam/x509-identity-mgmt/js/src/express/routes/contentNegotiation.js
@@ -1,0 +1,43 @@
+const HttpStatus = require('http-status-codes');
+
+const ContentType = {
+  pem: 'application/x-pem-file',
+  json: 'application/json',
+};
+
+/**
+ * Middleware builder function used to check if the specified content types are
+ * acceptable, based on the request’s Accept HTTP header field.
+ *
+ * @param {array}  accepts      array with all supported MIME types. The order of the
+ *                              array is significant (server preferred order)
+ * @param {object} contentTypes object whose attributes are used for serving different
+ *                              representations of a resource at the same URI.
+ * @returns Returns a Middleware.
+ */
+function contentNegotiation(accepts, contentTypes) {
+  return (req, res) => {
+    // The response object must have been previously formed with the necessary
+    // data to build the content in all supported representations!
+
+    // The method returns the best match, or if none of the specified content
+    // types is acceptable, returns false (in which case, the application
+    // should respond with 406 "Not Acceptable").
+    const accept = req.accepts(accepts);
+
+    if (accept === false || !Reflect.has(contentTypes, accept)) {
+      res.sendStatus(HttpStatus.NOT_ACCEPTABLE);
+    } else {
+      // By default express framework encodes all responses in UTF-8
+      res.set('Content-Type', `${accept}; charset=utf-8`);
+
+      // serves the content in the representation accepted by the client.
+      Reflect.get(contentTypes, accept)(res);
+    }
+  };
+}
+
+module.exports = {
+  ContentType,
+  contentNegotiation,
+};

--- a/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
+++ b/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
@@ -11,6 +11,7 @@ const CA_SERVICE = 'internalCAService';
 const TRUSTED_CA_SERVICE = 'trustedCAService';
 
 const accepts = [ContentType.pem, ContentType.json];
+const contentDispositionHeader = 'Content-Disposition';
 
 module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
   const { validateRegOrGenCert } = schemaValidator;
@@ -43,7 +44,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
           },
           contentNegotiation(accepts, {
             'application/x-pem-file': (res) => {
-              res.set('Content-Disposition', 'attachment; filename="cert.pem"');
+              res.set(contentDispositionHeader, 'attachment; filename="cert.pem"');
               res.status(HttpStatus.CREATED).send(
                 Buffer.from(res.result.certificatePem),
               );
@@ -74,7 +75,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
           },
           contentNegotiation(accepts, {
             'application/x-pem-file': (res) => {
-              res.set('Content-Disposition', 'attachment; filename="ca.pem"');
+              res.set(contentDispositionHeader, 'attachment; filename="ca.pem"');
               res.status(HttpStatus.OK).send(
                 Buffer.from(res.result.caPem),
               );
@@ -112,7 +113,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
           },
           contentNegotiation(accepts, {
             'application/x-pem-file': (res) => {
-              res.set('Content-Disposition', 'attachment; filename="cabundle.pem"');
+              res.set(contentDispositionHeader, 'attachment; filename="cabundle.pem"');
               res.status(HttpStatus.OK).send(
                 Buffer.from(res.bundle.join('\n')),
               );
@@ -143,7 +144,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
           },
           contentNegotiation(accepts, {
             'application/x-pem-file': (res) => {
-              res.set('Content-Disposition', 'attachment; filename="crl.pem"');
+              res.set(contentDispositionHeader, 'attachment; filename="crl.pem"');
               res.status(HttpStatus.OK).send(
                 Buffer.from(res.result.crl),
               );

--- a/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
+++ b/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
@@ -13,6 +13,13 @@ const TRUSTED_CA_SERVICE = 'trustedCAService';
 const accepts = [ContentType.pem, ContentType.json];
 const contentDispositionHeader = 'Content-Disposition';
 
+function servePem(res, status, filename, content) {
+  res.set(contentDispositionHeader, `attachment; filename="${filename}"`);
+  res.status(status).send(
+    Buffer.from(content),
+  );
+}
+
 module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
   const { validateRegOrGenCert } = schemaValidator;
   const { BadRequest } = errorTemplate;
@@ -43,12 +50,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
             }
           },
           contentNegotiation(accepts, {
-            'application/x-pem-file': (res) => {
-              res.set(contentDispositionHeader, 'attachment; filename="cert.pem"');
-              res.status(HttpStatus.CREATED).send(
-                Buffer.from(res.result.certificatePem),
-              );
-            },
+            'application/x-pem-file': (res) => servePem(res, HttpStatus.CREATED, 'cert.pem', res.result.certificatePem),
             'application/json': (res) => {
               res.status(HttpStatus.CREATED).json(res.result);
             },
@@ -74,12 +76,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
             next();
           },
           contentNegotiation(accepts, {
-            'application/x-pem-file': (res) => {
-              res.set(contentDispositionHeader, 'attachment; filename="ca.pem"');
-              res.status(HttpStatus.OK).send(
-                Buffer.from(res.result.caPem),
-              );
-            },
+            'application/x-pem-file': (res) => servePem(res, HttpStatus.OK, 'ca.pem', res.result.caPem),
             'application/json': (res) => {
               res.status(HttpStatus.OK).json(res.result);
             },
@@ -112,12 +109,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
             next();
           },
           contentNegotiation(accepts, {
-            'application/x-pem-file': (res) => {
-              res.set(contentDispositionHeader, 'attachment; filename="cabundle.pem"');
-              res.status(HttpStatus.OK).send(
-                Buffer.from(res.bundle.join('\n')),
-              );
-            },
+            'application/x-pem-file': (res) => servePem(res, HttpStatus.OK, 'cabundle.pem', res.bundle.join('\n')),
             'application/json': (res) => {
               res.status(HttpStatus.OK).json(res.bundle);
             },
@@ -143,12 +135,7 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
             next();
           },
           contentNegotiation(accepts, {
-            'application/x-pem-file': (res) => {
-              res.set(contentDispositionHeader, 'attachment; filename="crl.pem"');
-              res.status(HttpStatus.OK).send(
-                Buffer.from(res.result.crl),
-              );
-            },
+            'application/x-pem-file': (res) => servePem(res, HttpStatus.OK, 'crl.pem', res.result.crl),
             'application/json': (res) => {
               res.status(HttpStatus.OK).json(res.result);
             },

--- a/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
+++ b/iam/x509-identity-mgmt/js/src/express/routes/throwAwayRoutes.js
@@ -1,5 +1,7 @@
 const HttpStatus = require('http-status-codes');
 
+const { ContentType, contentNegotiation } = require('./contentNegotiation');
+
 const sanitizeParams = require('./sanitizeParams');
 
 const CERT_SERVICE = 'certificateService';
@@ -7,6 +9,8 @@ const CERT_SERVICE = 'certificateService';
 const CA_SERVICE = 'internalCAService';
 
 const TRUSTED_CA_SERVICE = 'trustedCAService';
+
+const accepts = [ContentType.pem, ContentType.json];
 
 module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
   const { validateRegOrGenCert } = schemaValidator;
@@ -23,21 +27,31 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
         method: 'post',
         middleware: [
           validateRegOrGenCert(),
-          async (req, res) => {
-            let result = null;
+          async (req, res, next) => {
             if (req.body.csr) {
               const csr = sanitizeParams.sanitizeLineBreaks(req.body.csr);
               const belongsTo = req.body.belongsTo || {};
 
               const certService = req.scope.resolve(CERT_SERVICE);
-              result = await certService.throwAwayCertificate({
+              res.result = await certService.throwAwayCertificate({
                 csr, belongsTo,
               });
+              next();
             } else {
               throw BadRequest('It is necessary to inform the CSR for the certificate to be issued.');
             }
-            res.status(HttpStatus.CREATED).json(result);
           },
+          contentNegotiation(accepts, {
+            'application/x-pem-file': (res) => {
+              res.set('Content-Disposition', 'attachment; filename="cert.pem"');
+              res.status(HttpStatus.CREATED).send(
+                Buffer.from(res.result.certificatePem),
+              );
+            },
+            'application/json': (res) => {
+              res.status(HttpStatus.CREATED).json(res.result);
+            },
+          }),
         ],
       },
     ],
@@ -53,11 +67,22 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
          * Used only by services behind the API gateway */
         method: 'get',
         middleware: [
-          async (req, res) => {
+          async (req, res, next) => {
             const caService = req.scope.resolve(CA_SERVICE);
-            const result = await caService.getRootCertificate();
-            res.status(HttpStatus.OK).json(result);
+            res.result = await caService.getRootCertificate();
+            next();
           },
+          contentNegotiation(accepts, {
+            'application/x-pem-file': (res) => {
+              res.set('Content-Disposition', 'attachment; filename="ca.pem"');
+              res.status(HttpStatus.OK).send(
+                Buffer.from(res.result.caPem),
+              );
+            },
+            'application/json': (res) => {
+              res.status(HttpStatus.OK).json(res.result);
+            },
+          }),
         ],
       },
     ],
@@ -82,29 +107,20 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
             const trustedBundle = await trustedCaService.getCertificateBundle();
 
             // The bundle will always contain the platform's internal CA certificate first
-            const bundle = [caPem, ...trustedBundle];
-
-            res.bundle = bundle;
+            res.bundle = [caPem, ...trustedBundle];
             next();
           },
-          (req, res) => {
-            // the order of this list is significant; should be server preferred order
-            switch (req.accepts(['application/x-pem-file', 'application/json'])) {
-              case 'application/x-pem-file':
-                res.set('Content-Type', 'application/x-pem-file; charset=utf-8');
-                res.set('Content-Disposition', 'attachment; filename="trustedca_bundle.pem"');
-                res.status(HttpStatus.OK).send(
-                  Buffer.from(res.bundle.join('\n')),
-                );
-                break;
-              case 'application/json':
-                res.set('Content-Type', 'application/json; charset=utf-8');
-                res.status(HttpStatus.OK).json(res.bundle);
-                break;
-              default:
-                res.sendStatus(HttpStatus.NOT_ACCEPTABLE);
-            }
-          },
+          contentNegotiation(accepts, {
+            'application/x-pem-file': (res) => {
+              res.set('Content-Disposition', 'attachment; filename="cabundle.pem"');
+              res.status(HttpStatus.OK).send(
+                Buffer.from(res.bundle.join('\n')),
+              );
+            },
+            'application/json': (res) => {
+              res.status(HttpStatus.OK).json(res.bundle);
+            },
+          }),
         ],
       },
     ],
@@ -120,11 +136,22 @@ module.exports = ({ mountPoint, schemaValidator, errorTemplate }) => {
          * Used only by services behind the API gateway */
         method: 'get',
         middleware: [
-          async (req, res) => {
+          async (req, res, next) => {
             const caService = req.scope.resolve(CA_SERVICE);
-            const result = await caService.getRootCRL(req.query.update === 'true');
-            res.status(HttpStatus.OK).json(result);
+            res.result = await caService.getRootCRL(req.query.update === 'true');
+            next();
           },
+          contentNegotiation(accepts, {
+            'application/x-pem-file': (res) => {
+              res.set('Content-Disposition', 'attachment; filename="crl.pem"');
+              res.status(HttpStatus.OK).send(
+                Buffer.from(res.result.crl),
+              );
+            },
+            'application/json': (res) => {
+              res.status(HttpStatus.OK).json(res.result);
+            },
+          }),
         ],
       },
     ],

--- a/iam/x509-identity-mgmt/js/tests/unitary/express/routes/throwAwayRoutes.test.js
+++ b/iam/x509-identity-mgmt/js/tests/unitary/express/routes/throwAwayRoutes.test.js
@@ -53,16 +53,27 @@ const framework = WebUtils.framework.createExpress({
 const request = supertest(framework);
 
 describe("Testing 'throwAwayRoutes.js' Script Routes", () => {
-  it('should post a CSR and receive a certificate',
+  it('should post a CSR and receive a certificate ("Accept: application/json")',
     () => request.post('/internal/api/v1/throw-away')
+      .set('Accept', 'application/json')
       .send({ csr: util.p256CSR })
       .expect(201)
       .then((res) => {
         expect(res.body).toEqual(generatedCert);
       }));
 
+  it('should post a CSR and receive a certificate ("Accept: application/x-pem-file")',
+    () => request.post('/internal/api/v1/throw-away')
+      .set('Accept', 'application/x-pem-file')
+      .send({ csr: util.p256CSR })
+      .expect(201)
+      .then((res) => {
+        expect(res.text).toEqual(generatedCert.certificatePem);
+      }));
+
   it('should return an error because the CSR was not provided',
     () => request.post('/internal/api/v1/throw-away')
+      .set('Accept', 'application/json')
       .send({
         certificateChain: util.certChain.join('\n').replace(/^(\s*)(.*)(\s*$)/gm, '$2'),
       })
@@ -73,18 +84,37 @@ describe("Testing 'throwAwayRoutes.js' Script Routes", () => {
         });
       }));
 
-  it('should get the internal Root CA',
+  it('should get the internal Root CA ("Accept: application/json")',
     () => request.get('/internal/api/v1/throw-away/ca')
+      .set('Accept', 'application/json')
       .expect(200)
       .then((res) => {
         expect(res.body).toEqual(caQueryResult);
       }));
 
-  it('should get the latest CRL issued by the internal Root CA',
+  it('should get the internal Root CA ("Accept: application/x-pem-file")',
+    () => request.get('/internal/api/v1/throw-away/ca')
+      .set('Accept', 'application/x-pem-file')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).toEqual(caQueryResult.caPem);
+      }));
+
+
+  it('should get the latest CRL issued by the internal Root CA ("Accept: application/json")',
     () => request.get('/internal/api/v1/throw-away/ca/crl')
+      .set('Accept', 'application/json')
       .expect(200)
       .then((res) => {
         expect(res.body).toEqual(crlQueryResult);
+      }));
+
+  it('should get the latest CRL issued by the internal Root CA ("Accept: application/x-pem-file")',
+    () => request.get('/internal/api/v1/throw-away/ca/crl')
+      .set('Accept', 'application/x-pem-file')
+      .expect(200)
+      .then((res) => {
+        expect(res.text).toEqual(crlQueryResult.crl);
       }));
 
   it('should get the Trusted CAs bundle ("Accept: application/json")',


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

The service currently provides response content only in JSON format

* **What is the new behavior (if this is a feature change)?**

In addition to the JSON format, the service now responds by default in the PEM-File format

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

The other services that use internal endpoints (`cert-sidecar` service) must provide the `Accept: application/json` header to continue to receive data in JSON format, otherwise, they will receive it in `application/x-pem-file`.

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#1940

* **Other information**:

After the approval of this PR, it will be necessary to change the `cert-sidecar` service.
