### PR TITLE
[cert-sidecar] Payload to associate certificate with the application (belongsTo)

### DIFF
--- a/tools/cert-sidecar/README.md
+++ b/tools/cert-sidecar/README.md
@@ -106,6 +106,8 @@ Certificates configurations
 | certs.files.cert | Public certificate filename | cert.pem | filename  | CERT_SC_CERTS_FILES_CERT
 | certs.files.crl | CRL filename  | crl.pem | filename | CERT_SC_CERTS_FILES_CRL
 | certs.files.key | Private keys filename | key.pem | filename | CERT_SC_CERTS_FILES_KEY
+| certs.belongsto.application | Application to which the generated certificate must belong. | `''` | `'vernemq'`, `'v2k'`, `'k2v'` | CERT_SC_CERTS_BELONGSTO_APPLICATION
+
 
 #### Cron
 

--- a/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
+++ b/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
@@ -255,7 +255,10 @@ class Certificates {
           configCerts['common.name'],
           configCerts.hostnames,
         );
-      const cert = await this.x509IdentityMgmt.getRequests().createCertificateByCSR(csr);
+      const belongsTo = {
+        application: configCerts['belongsto.application'],
+      };
+      const cert = await this.x509IdentityMgmt.getRequests().createCertificateByCSR(csr, belongsTo);
       this.cert = cert;
       await createFile(this.pathCert, this.cert);
     } catch (e) {

--- a/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
+++ b/tools/cert-sidecar/app/x509IdentityMgmt/Requests.js
@@ -51,19 +51,21 @@ class Requests {
    * Creates a X.509 certificate using a Certificate Signing Request (CSR).
    *
    * @param {String} csr PEM encoded CSR
+   * @param {Object} belongsTo Application in which the generated certificate
+   *                           must belong (be associated).
    *
    * @throws Will throw an error if cannot create a certificate from a CSR
    *
    * @returns {String|null}  PEM encoded  certificate
    */
-  async createCertificateByCSR(csr) {
+  async createCertificateByCSR(csr, belongsTo) {
     this.logger.debug('createCert: Creating a certificate from a CSR...');
     try {
       const {
         status,
         statusText,
         data,
-      } = await this.axiosX509.post(this.paths.sign, { csr }, axiosCfg);
+      } = await this.axiosX509.post(this.paths.sign, { csr, belongsTo }, axiosCfg);
 
       if (status === 201) {
         return data;

--- a/tools/cert-sidecar/config/default.conf
+++ b/tools/cert-sidecar/config/default.conf
@@ -51,6 +51,7 @@ cron.cabundle.time:string=0 0 */1 * * *
 #Certificates config
 certs.hostnames:string[]=["localhost"]
 certs.common.name:string=${HOSTNAME:-generic-commonName}
+certs.belongsto.application:string=
 certs.expiration.checkend.sec:integer=43200
 certs.crl:boolean=true
 certs.files.basepath:string=/certs

--- a/tools/cert-sidecar/test/integration/CertificatesMgmt.test.js
+++ b/tools/cert-sidecar/test/integration/CertificatesMgmt.test.js
@@ -16,6 +16,7 @@ const mockConfig = {
   certs: {
     hostnames: ['localhost'],
     'common.name': 'generic-commonName',
+    'belongsto.application': 'vernemq',
     'expiration.checkend.sec': 43200,
     crl: true,
     'files.basepath': 'certs',
@@ -144,7 +145,7 @@ describe('CertificatesMgmt', () => {
     expect(mockGenerateCsr).toHaveBeenCalledWith('PrivateKey',
       mockConfig.certs['common.name'], mockConfig.certs.hostnames);
     expect(mockCreateCertificateByCSR)
-      .toHaveBeenCalledWith('CSR');
+      .toHaveBeenCalledWith('CSR', { application: 'vernemq' });
     expect(mockUtil.createFile).toHaveBeenCalledWith('certs/cert.pem', 'Cert');
 
     // retrieveCaCert


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The cert-sidecar generated the certificate but did not associate it with the correct application in x509-identity-mgmt

* **What is the new behavior (if this is a feature change)?**

The sidecar in addition to informing the CSR, also tells which application the certificate should belong to.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#1940

* **Other information**:
