### PR TITLE
[cert-sidecar] Configuration parameter changed (Name of the application in which the sidecar will be associated)

### DIFF
--- a/tools/cert-sidecar/README.md
+++ b/tools/cert-sidecar/README.md
@@ -82,7 +82,7 @@ General configurations
 
 | Key | Purpose | Default Value | Valid Values | Environment variable
 | --- | ------- | ------------- | ------------ | --------------------
-| app.sidecar.to      | Suffix to be used to identify logs | app | string | CERT_SC_APP_SIDECAR_TO
+| app.sidecar.to      | Name of the application in which the sidecar will be associated. **Note:** The `x509-identity-mgmt` service must be configured to recognize the _application name_ as valid. | app | string | CERT_SC_APP_SIDECAR_TO
 | app.delete.certificates  | Enables deleting certificate files if you are unable to connect and retrieve a new one after a given number of attempts | false | boolean | CERT_SC_APP_DELETE_CERTIFICATES
 | app.shutdown  | Enables the service to gracefully shut down if after a given number of attempts it is not possible to obtain new certificates | true | boolean | CERT_SC_APP_SHUTDOWN
 | log.console.level   | Console logger level | info | info, debug, error, warn | CERT_SC_LOG_CONSOLE_LEVEL
@@ -106,7 +106,6 @@ Certificates configurations
 | certs.files.cert | Public certificate filename | cert.pem | filename  | CERT_SC_CERTS_FILES_CERT
 | certs.files.crl | CRL filename  | crl.pem | filename | CERT_SC_CERTS_FILES_CRL
 | certs.files.key | Private keys filename | key.pem | filename | CERT_SC_CERTS_FILES_KEY
-| certs.belongsto.application | Application to which the generated certificate must belong. The values are [enumerated](https://github.com/dojot/dojot/blob/development/iam/x509-identity-mgmt/js/schemas/defs.json) by the `x509-identity-mgmt` service | `''` | `'vernemq'`, `'v2k'`, `'k2v'` | CERT_SC_CERTS_BELONGSTO_APPLICATION
 
 #### Cron
 

--- a/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
+++ b/tools/cert-sidecar/app/certificatesMgmt/Certificates.js
@@ -256,7 +256,7 @@ class Certificates {
           configCerts.hostnames,
         );
       const belongsTo = {
-        application: configCerts['belongsto.application'],
+        application: configApp['sidecar.to'],
       };
       const cert = await this.x509IdentityMgmt.getRequests().createCertificateByCSR(csr, belongsTo);
       this.cert = cert;

--- a/tools/cert-sidecar/config/default.conf
+++ b/tools/cert-sidecar/config/default.conf
@@ -51,7 +51,6 @@ cron.cabundle.time:string=0 0 */1 * * *
 #Certificates config
 certs.hostnames:string[]=["localhost"]
 certs.common.name:string=${HOSTNAME:-generic-commonName}
-certs.belongsto.application:string=
 certs.expiration.checkend.sec:integer=43200
 certs.crl:boolean=true
 certs.files.basepath:string=/certs

--- a/tools/cert-sidecar/test/integration/CertificatesMgmt.test.js
+++ b/tools/cert-sidecar/test/integration/CertificatesMgmt.test.js
@@ -16,7 +16,6 @@ const mockConfig = {
   certs: {
     hostnames: ['localhost'],
     'common.name': 'generic-commonName',
-    'belongsto.application': 'vernemq',
     'expiration.checkend.sec': 43200,
     crl: true,
     'files.basepath': 'certs',
@@ -145,7 +144,7 @@ describe('CertificatesMgmt', () => {
     expect(mockGenerateCsr).toHaveBeenCalledWith('PrivateKey',
       mockConfig.certs['common.name'], mockConfig.certs.hostnames);
     expect(mockCreateCertificateByCSR)
-      .toHaveBeenCalledWith('CSR', { application: 'vernemq' });
+      .toHaveBeenCalledWith('CSR', { application: mockConfig.app['sidecar.to'] });
     expect(mockUtil.createFile).toHaveBeenCalledWith('certs/cert.pem', 'Cert');
 
     // retrieveCaCert


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

configuration update

* **What is the current behavior?** (You can also link to an open issue here)

There was an additional parameter to inform the name of the application to which the certificate retrieved by the sidecar would be associated with.

* **What is the new behavior (if this is a feature change)?**

The additional parameter was removed, as there was no need for it, since there was already a correct parameter for this.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot##1940

* **Other information**:

The name of the application (`CERT_SC_APP_SIDECAR_TO`) must be identical to the one informed in the `x509-identity-mgmt` service settings (https://github.com/dojot/dojot/pull/2064).
