### PR TITLE
[cert-sidecar] Increasing the request cert timeout

### DIFF
--- a/tools/cert-sidecar/config/default.conf
+++ b/tools/cert-sidecar/config/default.conf
@@ -6,7 +6,7 @@ x509.path.crl:string=/internal/api/v1/throw-away/ca/crl
 x509.path.ca:string=/internal/api/v1/throw-away/ca
 x509.path.cabundle:string=/internal/api/v1/throw-away/ca/bundle
 x509.retries:integer=9
-x509.timeout.ms:integer=1000
+x509.timeout.ms:integer=10000
 x509.healthchecker.ms:integer=60000
 
 #Geral config


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

config update

* **What is the current behavior?** (You can also link to an open issue here)

Certificate request timeout is 1 second

* **What is the new behavior (if this is a feature change)?**

The certificate request timeout should be more conservative, in 10 seconds

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

The timeout problem was observed when developing the ticket:
dojot/dojot#1940

* **Other information**:

The reason for this change is that the first certificate (when the EJBCA server boots) takes a while to generate, at which point the cert-sidecar cancels the request and tries again, this causes the x509-identity-mgmt service to publish an event certificate association in Kafka unnecessary, since it does not cancel the issuance of the certificate, even though the cert-sidecar cancels the API call.