### PR TITLE
[x509-identity-mgmt] Fix device-id length schema

### DIFF
--- a/iam/x509-identity-mgmt/js/schemas/defs.json
+++ b/iam/x509-identity-mgmt/js/schemas/defs.json
@@ -45,7 +45,7 @@
           "title": "Device ID",
           "description": "Identifies the device that the x.509 certificate is attached to.",
           "maxLength": 36,
-          "pattern": "^[0-9a-fA-F-]{6,36}$"
+          "pattern": "^[0-9a-fA-F-]{5,36}$"
         },
         "application": {
           "type": [

--- a/iam/x509-identity-mgmt/js/tests/json-schema/certificates.test.js
+++ b/iam/x509-identity-mgmt/js/tests/json-schema/certificates.test.js
@@ -394,9 +394,9 @@ describe('X509 Certificates - JSON Schema validations [on http POST]', () => {
               dataPath: '.belongsTo.device',
               schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/pattern',
               params: {
-                pattern: '^[0-9a-fA-F-]{6,36}$',
+                pattern: '^[0-9a-fA-F-]{5,36}$',
               },
-              message: 'should match pattern "^[0-9a-fA-F-]{6,36}$"',
+              message: 'should match pattern "^[0-9a-fA-F-]{5,36}$"',
             }],
           },
         });
@@ -609,9 +609,9 @@ describe('X509 Certificates - JSON Schema validations [on http PATCH]', () => {
               dataPath: '.belongsTo.device',
               schemaPath: 'https://raw.githubusercontent.com/dojot/dojot/development/iam/x509-identity-mgmt/js/schemas/defs.json#/definitions/belongsTo/properties/device/pattern',
               params: {
-                pattern: '^[0-9a-fA-F-]{6,36}$',
+                pattern: '^[0-9a-fA-F-]{5,36}$',
               },
-              message: 'should match pattern "^[0-9a-fA-F-]{6,36}$"',
+              message: 'should match pattern "^[0-9a-fA-F-]{5,36}$"',
             }],
           },
         });


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The device ID validation schema requires a minimum of 6 characters, but sometimes the device ID has 5 characters.

* **What is the new behavior (if this is a feature change)?**

The device ID validation schema now requires a minimum of 5 characters.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

* **Other information**:
