### PR TITLE
[rel/v0.6.0] Correction of EJBCA script

### DIFF
--- a/x509-identity-mgmt/ejbca/bin/dojot-custom/exec.sh
+++ b/x509-identity-mgmt/ejbca/bin/dojot-custom/exec.sh
@@ -28,13 +28,15 @@ function main() {
             echo
             log "INFO" "Lock obtained successfully. Starting the configuration process..."
 
+            # The batch certificate issuance settings must
+            # be recreated every time the container boots
+            batchIssuanceConfig
+
             local caFound
             caFound=$(ejbca_cmd ca listcas 2>&1 | grep "CA Name: ${DEVICES_CA}")
 
             # If the CA is not found, we must run a new CA Setup...
             if [ "x${caFound}" == "x" ]; then
-
-                batchIssuanceConfig
 
                 importProfiles
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The problem is that when the EJBCA container is dropped, the new one that is created does not have the configuration file for issuing certificates with more secure keys.

* **What is the new behavior (if this is a feature change)?**

The fix causes the configuration file to be recreated for each new container.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Is there any issue related to this PR? (Link to an issue, e.g. #99999)** 

dojot/dojot#2083

* **Other information**:

Branch `development` already has this fix