### PR TITLE
Refactored the process of including a timestamp

### DIFF
--- a/connector/mqtt/vernemq/v2k-bridge/test/unit/AgentMessenger.test.js
+++ b/connector/mqtt/vernemq/v2k-bridge/test/unit/AgentMessenger.test.js
@@ -1,9 +1,4 @@
-jest.mock('../../app/Utils');
-jest.mock('../../app/MQTTClient.js');
-
 const mockProcess = require('jest-mock-process');
-const utils = require('../../app/Utils');
-const AgentMessenger = require('../../app/AgentMessenger');
 
 const mockExit = mockProcess.mockProcessExit();
 
@@ -86,6 +81,13 @@ jest.mock('@dojot/microservice-sdk', () => ({
     getConfig: jest.fn(() => mockConfig.ConfigManager),
   },
 }));
+
+const AgentMessenger = require('../../app/AgentMessenger');
+
+jest.mock('../../app/Utils');
+jest.mock('../../app/MQTTClient.js');
+
+const utils = require('../../app/Utils');
 
 describe('AgentMessenger', () => {
   let agentMessenger;

--- a/connector/mqtt/vernemq/v2k-bridge/test/unit/Utils.test.js
+++ b/connector/mqtt/vernemq/v2k-bridge/test/unit/Utils.test.js
@@ -1,65 +1,130 @@
 const utils = require('../../app/Utils');
 
+jest.mock('@dojot/microservice-sdk', () => ({
+  Logger: jest.fn(() => ({ warn: jest.fn() })),
+}));
+
+// mock Date.now()
+const DATE_NOW = 1631110777091;
+Date.now = jest.fn(() => DATE_NOW);
+
 describe('Utils', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('generateDojotDeviceDataMessage', () => {
-    it('Case 1 - Payload without timestamp', () => {
-      const topic = 'admin:deviceid/topic';
-      const payload = JSON.parse('{"temperatura":10}');
-      const data = utils.generateDojotDeviceDataMessage(topic, payload);
-
-      const { deviceid } = data.metadata;
-      const { tenant } = data.metadata;
-      const { attrs } = data;
-      let { tsCheck } = true;
-
-      if ("timestamp".indexOf(payload)) {
-        tsCheck = false;
-      }
-
-      expect(deviceid).toEqual('deviceid');
-      expect(tenant).toEqual('admin');
-      expect(attrs).toEqual(payload);
-      expect(tsCheck).toEqual(false);
+    it('Payload without timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = { temperature: 10 };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: DATE_NOW,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
     });
-  });
 
-  describe('generateDojotDeviceDataMessage', () => {
-    it('Case 2 - payload with Unix timestamp', () => {
-      const topic = 'admin:deviceid/topic';
-      const payload = JSON.parse('{"temperatura":10,"timestamp":1605093071000}');
-      const data = utils.generateDojotDeviceDataMessage(topic, payload);
-
-      const { deviceid } = data.metadata;
-      const { tenant } = data.metadata;
-      const { attrs } = data;
-
-      expect(deviceid).toEqual('deviceid');
-      expect(tenant).toEqual('admin');
-      expect(attrs).toEqual(payload);
-      expect(data.metadata.timestamp).not.toBeNaN();
-      expect(data.metadata.timestamp).toEqual(1605093071000);
+    it('Payload with Unix timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = {
+        temperature: 10,
+        timestamp: 1605093071000,
+      };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: 1605093071000,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
     });
-  });
 
-  describe('generateDojotDeviceDataMessage', () => {
-    it('Case 3 - payload with String timestamp', () => {
-      const topic = 'admin:deviceid/topic';
-      const payload = JSON.parse('{"temperatura":10, "timestamp":"2020-05-05T05:00:00.000000Z"}');
-      const data = utils.generateDojotDeviceDataMessage(topic, payload);
+    it('Payload with String timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = {
+        temperature: 10,
+        timestamp: '2020-05-05T05:00:00.000000Z',
+      };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: 1588654800000,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
+    });
 
-      const { deviceid } = data.metadata;
-      const { tenant } = data.metadata;
-      const { attrs } = data;
+    it('Payload with invalid unix timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = {
+        temperature: 10,
+        timestamp: Number.NaN,
+      };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: DATE_NOW,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
+    });
 
-      expect(deviceid).toEqual('deviceid');
-      expect(tenant).toEqual('admin');
-      expect(attrs).toEqual(payload);
-      expect(data.metadata.timestamp).not.toBeNaN();
-      expect(data.metadata.timestamp).toEqual(1588654800000);
+    it('Payload with invalid string timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = {
+        temperature: 10,
+        timestamp: 'invalid timestamp',
+      };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: DATE_NOW,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
+    });
+
+    it('Payload with invalid type of timestamp', () => {
+      const topic = 'tenant:device/attrs';
+      const payload = {
+        temperature: 10,
+        timestamp: true,
+      };
+      const msg = utils.generateDojotDeviceDataMessage(topic, payload);
+      const expectedMsg = {
+        metadata: {
+          tenant: 'tenant',
+          deviceid: 'device',
+          timestamp: DATE_NOW,
+        },
+        attrs: {
+          temperature: 10,
+        },
+      };
+      expect(msg).toMatchObject(expectedMsg);
     });
   });
 


### PR DESCRIPTION
If there is a timestamp in the original message, it will be used;
otherwise, it will be used the current time.

* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
The current time is not being used as timestamp when the original messages hasn't got a valid timestamp.


* **What is the new behavior (if this is a feature change)?**
Fixed the problem reported above.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


* **Other information**:

Related to #2186