### PR TITLE
[ file-mgmt ] - GitHub Actions - GH Pages

### DIFF
--- a/.github/workflows/file-mgmt.yml
+++ b/.github/workflows/file-mgmt.yml
@@ -65,3 +65,39 @@ jobs:
           workdir: storage/file/minio/file-mgmt
           buildoptions: " --label 'commit_sha'='${{ github.sha }}' " # label with commit that built image
           tag_names: true # tag will be based in branch name or tag name
+
+  gh-pages:
+    needs:
+    name: (storage/file/minio/file-mgmt) Generate documentation and Publish in gh-pages
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'refs/pull/') == false # if this a PR doesn't run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Version Doc
+        id: version_doc
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          export TAG_VERSION=$(sh .github/workflows/scripts/translate_docker_tag.sh)
+          echo Documentation Version $TAG_VERSION
+          echo ::set-output name=version::$TAG_VERSION
+      # I need to improve this, find another way to do
+      - name: Generate docs
+        env:
+          FOLDER_TO_GH_PAGES: storage/file/minio/file-mgmt
+          PATH_SWAGGER_YML: ./storage/file/minio/file-mgmt/docs/v1.yml
+          VERSION_NAME: ${{ steps.version_doc.outputs.version }}
+        run: |
+          sh .github/workflows/scripts/swagger.sh
+      - name: Publish Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./swagger-docs
+          destination_dir: storage/file/minio/file-mgmt
+          keep_files: true
+          allow_empty_commit: false

--- a/.github/workflows/file-mgmt.yml
+++ b/.github/workflows/file-mgmt.yml
@@ -67,7 +67,7 @@ jobs:
           tag_names: true # tag will be based in branch name or tag name
 
   gh-pages:
-    needs:
+    needs: unit-test
     name: (storage/file/minio/file-mgmt) Generate documentation and Publish in gh-pages
     runs-on: ubuntu-latest
     if: contains(github.ref, 'refs/pull/') == false # if this a PR doesn't run


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)
The file-mgmt service don't have an action for push documentation (GH pages)


* **What is the new behavior (if this is a feature change)?**
Now the file-mgmt service has GitHub Actions for GH pages


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
