### PR TITLE
[VerneMQ] Deprecate unencrypted git protocol use

### DIFF
--- a/connector/mqtt/vernemq/broker/Dockerfile
+++ b/connector/mqtt/vernemq/broker/Dockerfile
@@ -103,7 +103,8 @@ RUN apk add --no-cache --virtual .build-deps \
 COPY ./vernemq-${VERNEMQ_VERSION}-*.patch ./
 
 # Aplly patches
-RUN patch -p1 < vernemq-${VERNEMQ_VERSION}-fingerprint.patch \
+RUN patch -p1 < vernemq-${VERNEMQ_VERSION}-deprecate-git-protocol.patch \
+    && patch -p1 < vernemq-${VERNEMQ_VERSION}-fingerprint.patch \
     && patch -p1 < vernemq-${VERNEMQ_VERSION}-trusted-cert-refresh.patch
 
 COPY bin/build.sh build.sh

--- a/connector/mqtt/vernemq/broker/src/dojot_acl_plugin/rebar.config
+++ b/connector/mqtt/vernemq/broker/src/dojot_acl_plugin/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 {deps, [
-        {vernemq_dev, {git, "git://github.com/erlio/vernemq_dev.git", {branch, "master"}}}
+        {vernemq_dev, {git, "https://github.com/erlio/vernemq_dev.git", {branch, "master"}}}
        ]}.
 
 {relx, [{release, {dojot_acl_plugin, "0.0.1"},

--- a/connector/mqtt/vernemq/broker/src/dojot_acl_plugin/rebar.lock
+++ b/connector/mqtt/vernemq/broker/src/dojot_acl_plugin/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"vernemq_dev">>,
-  {git,"git://github.com/erlio/vernemq_dev.git",
+  {git,"https://github.com/erlio/vernemq_dev.git",
        {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
   0}].

--- a/connector/mqtt/vernemq/broker/src/dojot_disconnect_plugin/rebar.config
+++ b/connector/mqtt/vernemq/broker/src/dojot_disconnect_plugin/rebar.config
@@ -1,6 +1,6 @@
 %%-*- mode: erlang -*-
 {deps, [
-        {vernemq_dev, {git, "git://github.com/erlio/vernemq_dev.git", {branch, "master"}}}
+        {vernemq_dev, {git, "https://github.com/erlio/vernemq_dev.git", {branch, "master"}}}
        ]}.
 
 {relx, [{release, {dojot_disconnect_plugin, "0.0.1"},

--- a/connector/mqtt/vernemq/broker/src/dojot_disconnect_plugin/rebar.lock
+++ b/connector/mqtt/vernemq/broker/src/dojot_disconnect_plugin/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"vernemq_dev">>,
-  {git,"git://github.com/erlio/vernemq_dev.git",
+  {git,"https://github.com/erlio/vernemq_dev.git",
        {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
   0}].

--- a/connector/mqtt/vernemq/broker/vernemq-1.10.0-deprecate-git-protocol.patch
+++ b/connector/mqtt/vernemq/broker/vernemq-1.10.0-deprecate-git-protocol.patch
@@ -1,0 +1,434 @@
+diff -crB vernemq-1.10.0/apps/vmq_diversity/rebar.config vernemq-1.10.0-deprecate-git-protocol/apps/vmq_diversity/rebar.config
+*** vernemq-1.10.0/apps/vmq_diversity/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/apps/vmq_diversity/rebar.config	2022-03-28 16:06:40.267429433 -0300
+***************
+*** 9,26 ****
+          hackney,
+          {jsx, "2.10.0"},
+          {bcrypt, "1.0.2"},
+!         {gen_server2, {git, "git://github.com/erlio/gen_server2.git", {branch, "master"}}},
+!         {luerl, {git, "git://github.com/rvirding/luerl.git", {branch, "develop"}}},
+!         {emysql, {git, "git://github.com/djustinek/Emysql.git", "fa7c94b5237a56cec6d75c3d3b1e51060426e099"}},
+          %%Eonblast hasn't merged the Erlang 18 related PR from djustinek
+!         %%{emysql, {git, "git://github.com/Eonblast/Emysql.git", {tag, "v0.4.1"}}},
+!         {mongodb, {git, "git://github.com/comtihon/mongodb-erlang.git", {branch, "master"}}},
+!         {mcd, {git, "git://github.com/EchoTeam/mcd.git", {ref, "b5b4a32"}}}
+         ]}.
+  
+! {overrides, [{override, mongodb, 
+                %% use different bson-erlang fork, as we have a compile error in the official one
+!               [{deps, [{bson, {git, "git://github.com/vintenove/bson-erlang", {branch, "master"}}},
+                         {pbkdf2, {git, "https://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}}
+                        ]},
+                 {plugins, []}
+--- 9,26 ----
+          hackney,
+          {jsx, "2.10.0"},
+          {bcrypt, "1.0.2"},
+!         {gen_server2, {git, "https://github.com/erlio/gen_server2.git", {branch, "master"}}},
+!         {luerl, {git, "https://github.com/rvirding/luerl.git", {branch, "develop"}}},
+!         {emysql, {git, "https://github.com/djustinek/Emysql.git", "fa7c94b5237a56cec6d75c3d3b1e51060426e099"}},
+          %%Eonblast hasn't merged the Erlang 18 related PR from djustinek
+!         %%{emysql, {git, "https://github.com/Eonblast/Emysql.git", {tag, "v0.4.1"}}},
+!         {mongodb, {git, "https://github.com/comtihon/mongodb-erlang.git", {branch, "master"}}},
+!         {mcd, {git, "https://github.com/EchoTeam/mcd.git", {ref, "b5b4a32"}}}
+         ]}.
+  
+! {overrides, [{override, mongodb,
+                %% use different bson-erlang fork, as we have a compile error in the official one
+!               [{deps, [{bson, {git, "https://github.com/vintenove/bson-erlang", {branch, "master"}}},
+                         {pbkdf2, {git, "https://github.com/basho/erlang-pbkdf2.git", {tag, "2.0.0"}}}
+                        ]},
+                 {plugins, []}
+diff -crB vernemq-1.10.0/apps/vmq_generic_msg_store/rebar.config vernemq-1.10.0-deprecate-git-protocol/apps/vmq_generic_msg_store/rebar.config
+*** vernemq-1.10.0/apps/vmq_generic_msg_store/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/apps/vmq_generic_msg_store/rebar.config	2022-03-29 08:19:08.264344509 -0300
+***************
+*** 1,7 ****
+  {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+  {deps, [
+          lager,
+!         {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
+          {sext, "1.5.0"}
+         ]}.
+  
+--- 1,7 ----
+  {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+  {deps, [
+          lager,
+!         {eleveldb, {git, "https://github.com/dojot/eleveldb.git", "develop"}},
+          {sext, "1.5.0"}
+         ]}.
+  
+diff -crB vernemq-1.10.0/apps/vmq_plumtree/rebar.config vernemq-1.10.0-deprecate-git-protocol/apps/vmq_plumtree/rebar.config
+*** vernemq-1.10.0/apps/vmq_plumtree/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/apps/vmq_plumtree/rebar.config	2022-03-28 16:10:37.021192159 -0300
+***************
+*** 1,7 ****
+  {erl_opts, [debug_info]}.
+  {deps, [
+!         %% never heard of plumtree... it is an efficient gossiping protocol 
+!         %% bundled with a storage engine. Riak uses a similar mechanism for 
+          %% distributing cluster wide state information.
+!         {plumtree, {git, "git://github.com/vernemq/plumtree.git", {branch, "master"}}}
+         ]}.
+--- 1,7 ----
+  {erl_opts, [debug_info]}.
+  {deps, [
+!         %% never heard of plumtree... it is an efficient gossiping protocol
+!         %% bundled with a storage engine. Riak uses a similar mechanism for
+          %% distributing cluster wide state information.
+!         {plumtree, {git, "https://github.com/vernemq/plumtree.git", {branch, "master"}}}
+         ]}.
+diff -crB vernemq-1.10.0/apps/vmq_server/rebar.config vernemq-1.10.0-deprecate-git-protocol/apps/vmq_server/rebar.config
+*** vernemq-1.10.0/apps/vmq_server/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/apps/vmq_server/rebar.config	2022-03-28 16:10:04.860952713 -0300
+***************
+*** 1,8 ****
+  %%-*- mode: erlang -*-
+  {minimum_otp_vsn, "17.0"}.
+  {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
+!             {parse_transform, lager_transform}, 
+!             warnings_as_errors, 
+              debug_info]}.
+  {xref_checks, []}.
+  {deps, [
+--- 1,8 ----
+  %%-*- mode: erlang -*-
+  {minimum_otp_vsn, "17.0"}.
+  {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
+!             {parse_transform, lager_transform},
+!             warnings_as_errors,
+              debug_info]}.
+  {xref_checks, []}.
+  {deps, [
+***************
+*** 10,16 ****
+          {ranch, "1.7.1"},
+          {jsx, "2.10.0"},
+          {riak_sysmon, "2.1.2"},
+!         {gen_server2, {git, "git://github.com/erlio/gen_server2.git", {branch, "master"}}}
+         ]}.
+  
+  {cover_enabled, true}.
+--- 10,16 ----
+          {ranch, "1.7.1"},
+          {jsx, "2.10.0"},
+          {riak_sysmon, "2.1.2"},
+!         {gen_server2, {git, "https://github.com/erlio/gen_server2.git", {branch, "master"}}}
+         ]}.
+  
+  {cover_enabled, true}.
+diff -crB vernemq-1.10.0/apps/vmq_swc/rebar.config vernemq-1.10.0-deprecate-git-protocol/apps/vmq_swc/rebar.config
+*** vernemq-1.10.0/apps/vmq_swc/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/apps/vmq_swc/rebar.config	2022-03-29 08:20:02.612752042 -0300
+***************
+*** 2,14 ****
+  {deps, [
+          lager,
+          {sext, "1.5.0"},
+!         {swc, {git, "git://github.com/vernemq/ServerWideClocks.git", "master"}},
+!         {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", "develop"}},
+          riak_dt
+         ]}.
+  
+  {profiles, [{rocksdb, [{deps, [rocksdb]}]},
+!             {leveled, [{deps, [{leveled, {git, "git://github.com/martinsumner/leveled.git", {branch, "master"}}}]}]},
+              {test, [{deps, [triq]}]}]}.
+  
+  {cover_enabled, true}.
+--- 2,14 ----
+  {deps, [
+          lager,
+          {sext, "1.5.0"},
+!         {swc, {git, "https://github.com/vernemq/ServerWideClocks.git", "master"}},
+!         {eleveldb, {git, "https://github.com/dojot/eleveldb.git", "develop"}},
+          riak_dt
+         ]}.
+  
+  {profiles, [{rocksdb, [{deps, [rocksdb]}]},
+!             {leveled, [{deps, [{leveled, {git, "https://github.com/martinsumner/leveled.git", {branch, "master"}}}]}]},
+              {test, [{deps, [triq]}]}]}.
+  
+  {cover_enabled, true}.
+diff -crB vernemq-1.10.0/.gitmodules vernemq-1.10.0-deprecate-git-protocol/.gitmodules
+*** vernemq-1.10.0/.gitmodules	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/.gitmodules	2022-03-28 16:09:28.968685481 -0300
+***************
+*** 1,3 ****
+  [submodule "docs/sphinx_rtd_theme"]
+  	path = docs/sphinx_rtd_theme
+! 	url = git://github.com/dergraf/sphinx_rtd_theme.git
+--- 1,3 ----
+  [submodule "docs/sphinx_rtd_theme"]
+  	path = docs/sphinx_rtd_theme
+! 	url = https://github.com/dergraf/sphinx_rtd_theme.git
+diff -crB vernemq-1.10.0/rebar.config vernemq-1.10.0-deprecate-git-protocol/rebar.config
+*** vernemq-1.10.0/rebar.config	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/rebar.config	2022-03-29 08:20:38.297019620 -0300
+***************
+*** 4,10 ****
+              {platform_define, "20|21|22", nowarn_gen_fsm},
+              {platform_define, "^(R|1|20)", fun_stacktrace}]}.
+  {project_plugins, [
+!                    {rebar3_cuttlefish, {git, "git://github.com/vernemq/rebar3_cuttlefish",
+                                          {branch, "master"}}}]}.
+  {dialyzer, [{exclude_mods, [vmq_plugin]},
+              {plt_location, "plts"},
+--- 4,10 ----
+              {platform_define, "20|21|22", nowarn_gen_fsm},
+              {platform_define, "^(R|1|20)", fun_stacktrace}]}.
+  {project_plugins, [
+!                    {rebar3_cuttlefish, {git, "https://github.com/vernemq/rebar3_cuttlefish",
+                                          {branch, "master"}}}]}.
+  {dialyzer, [{exclude_mods, [vmq_plugin]},
+              {plt_location, "plts"},
+***************
+*** 14,26 ****
+          {recon, "2.3.2"},
+          {lager, "3.8.0"},
+          %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
+!         {cuttlefish, {git, "git://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
+!         {vernemq_dev, {git, "git://github.com/vernemq/vernemq_dev.git", {branch, "master"}}},
+  
+!         {lager_syslog, {git, "git://github.com/basho/lager_syslog.git", {tag, "3.0.1"}}},
+  
+          %% remove once clique hex package 3.0.2 is released
+!         {clique, {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}}
+         ]}.
+  
+  {overrides, [
+--- 14,26 ----
+          {recon, "2.3.2"},
+          {lager, "3.8.0"},
+          %% use specific cuttlefish commit until either 2.2.1 or 2.3.0 is relased.
+!         {cuttlefish, {git, "https://github.com/Kyorai/cuttlefish.git", {tag, "v2.3.0"}}},
+!         {vernemq_dev, {git, "https://github.com/vernemq/vernemq_dev.git", {branch, "master"}}},
+  
+!         {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {tag, "3.0.1"}}},
+  
+          %% remove once clique hex package 3.0.2 is released
+!         {clique, {git, "https://github.com/basho/clique.git", {tag, "0.3.5"}}}
+         ]}.
+  
+  {overrides, [
+***************
+*** 48,54 ****
+    {rpi32,
+     [{deps,
+        [
+!        {eleveldb, {git, "git://github.com/vernemq/eleveldb.git", {branch, "rpi-32"}}}
+        ]
+      },
+      %% Make sure the release generation can find the schema files is
+--- 48,54 ----
+    {rpi32,
+     [{deps,
+        [
+!        {eleveldb, {git, "https://github.com/dojot/eleveldb.git", {branch, "rpi-32"}}}
+        ]
+      },
+      %% Make sure the release generation can find the schema files is
+diff -crB vernemq-1.10.0/rebar.lock vernemq-1.10.0-deprecate-git-protocol/rebar.lock
+*** vernemq-1.10.0/rebar.lock	2019-11-26 07:11:10.000000000 -0300
+--- vernemq-1.10.0-deprecate-git-protocol/rebar.lock	2022-03-29 08:21:31.393417765 -0300
+***************
+*** 1,44 ****
+  {"1.1.0",
+  [{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.0.2">>},0},
+   {<<"bson">>,
+!   {git,"git://github.com/comtihon/bson-erlang",
+         {ref,"14308ab927cfa69324742c3de720578094e0bb19"}},
+    1},
+   {<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},1},
+   {<<"clique">>,
+!   {git,"git://github.com/basho/clique.git",
+         {ref,"0063cbe2c97aa3f00c1cb289678482cbc5524bc1"}},
+    0},
+   {<<"corman">>,
+!   {git,"git://github.com/EchoTeam/corman.git",
+         {ref,"1c1ae1c0aa97ed1976d9042ac9fb805b51214661"}},
+    1},
+   {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.6.3">>},0},
+   {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
+   {<<"cuttlefish">>,
+!   {git,"git://github.com/Kyorai/cuttlefish.git",
+         {ref,"27fc2d2f525e8e27dbe34b257ce3eb8beaff86c6"}},
+    0},
+   {<<"dht_ring">>,
+!   {git,"git://github.com/EchoTeam/dht_ring.git",
+         {ref,"d5b880ad76aefc81547dbb76b48a97a01d52ff41"}},
+    1},
+   {<<"edown">>,
+!   {git,"git://github.com/uwiger/edown.git",
+         {ref,"b7c8eb0ac1859f8fce11cbfe3526f5ec83194776"}},
+    1},
+   {<<"eleveldb">>,
+!   {git,"git://github.com/vernemq/eleveldb.git",
+!        {ref,"751961c905764ef947330773d6678cac5991d98f"}},
+    0},
+   {<<"emysql">>,
+!   {git,"git://github.com/djustinek/Emysql.git",
+         {ref,"fa7c94b5237a56cec6d75c3d3b1e51060426e099"}},
+    0},
+   {<<"epgsql">>,{pkg,<<"epgsql">>,<<"4.3.0">>},0},
+   {<<"eredis">>,{pkg,<<"eredis">>,<<"1.2.0">>},0},
+   {<<"gen_server2">>,
+!   {git,"git://github.com/erlio/gen_server2.git",
+         {ref,"32931bb9cdb6f637aa4f6a2065a4dbe09ca4c952"}},
+    0},
+   {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},1},
+--- 1,44 ----
+  {"1.1.0",
+  [{<<"bcrypt">>,{pkg,<<"bcrypt">>,<<"1.0.2">>},0},
+   {<<"bson">>,
+!   {git,"https://github.com/comtihon/bson-erlang",
+         {ref,"14308ab927cfa69324742c3de720578094e0bb19"}},
+    1},
+   {<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},1},
+   {<<"clique">>,
+!   {git,"https://github.com/basho/clique.git",
+         {ref,"0063cbe2c97aa3f00c1cb289678482cbc5524bc1"}},
+    0},
+   {<<"corman">>,
+!   {git,"https://github.com/EchoTeam/corman.git",
+         {ref,"1c1ae1c0aa97ed1976d9042ac9fb805b51214661"}},
+    1},
+   {<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.6.3">>},0},
+   {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
+   {<<"cuttlefish">>,
+!   {git,"https://github.com/Kyorai/cuttlefish.git",
+         {ref,"27fc2d2f525e8e27dbe34b257ce3eb8beaff86c6"}},
+    0},
+   {<<"dht_ring">>,
+!   {git,"https://github.com/EchoTeam/dht_ring.git",
+         {ref,"d5b880ad76aefc81547dbb76b48a97a01d52ff41"}},
+    1},
+   {<<"edown">>,
+!   {git,"https://github.com/uwiger/edown.git",
+         {ref,"b7c8eb0ac1859f8fce11cbfe3526f5ec83194776"}},
+    1},
+   {<<"eleveldb">>,
+!   {git,"https://github.com/dojot/eleveldb.git",
+!        {ref,"12739669377282d21b5f066c177c11a1a371610c"}},
+    0},
+   {<<"emysql">>,
+!   {git,"https://github.com/djustinek/Emysql.git",
+         {ref,"fa7c94b5237a56cec6d75c3d3b1e51060426e099"}},
+    0},
+   {<<"epgsql">>,{pkg,<<"epgsql">>,<<"4.3.0">>},0},
+   {<<"eredis">>,{pkg,<<"eredis">>,<<"1.2.0">>},0},
+   {<<"gen_server2">>,
+!   {git,"https://github.com/erlio/gen_server2.git",
+         {ref,"32931bb9cdb6f637aa4f6a2065a4dbe09ca4c952"}},
+    0},
+   {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},1},
+***************
+*** 48,100 ****
+   {<<"jsx">>,{pkg,<<"jsx">>,<<"2.10.0">>},0},
+   {<<"lager">>,{pkg,<<"lager">>,<<"3.8.0">>},0},
+   {<<"lager_syslog">>,
+!   {git,"git://github.com/basho/lager_syslog.git",
+         {ref,"126dd0284fcac9b01613189a82facf8d803411a2"}},
+    0},
+   {<<"luerl">>,
+!   {git,"git://github.com/rvirding/luerl.git",
+         {ref,"795192ccd812d14578b6bf3331ed8e67a6c8bf0b"}},
+    0},
+   {<<"mcd">>,
+!   {git,"git://github.com/EchoTeam/mcd.git",
+         {ref,"b5b4a32ef2c9e2f6a4faa992536cb3da3548e0f8"}},
+    0},
+   {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},1},
+   {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.2.0">>},1},
+   {<<"mongodb">>,
+!   {git,"git://github.com/comtihon/mongodb-erlang.git",
+         {ref,"9b53c4dcd931c48c5474dcdb8825e4b0afa2bff5"}},
+    0},
+   {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},2},
+   {<<"pbkdf2">>,
+!   {git,"git://github.com/comtihon/erlang-pbkdf2.git",
+         {ref,"7076584f5377e98600a7e2cb81980b2992fb2f71"}},
+    1},
+   {<<"plumtree">>,
+!   {git,"git://github.com/vernemq/plumtree.git",
+         {ref,"11cf17930e8acf29f9cdc90ae4796c9ceb7885eb"}},
+    0},
+   {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0},
+   {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},0},
+   {<<"recon">>,{pkg,<<"recon">>,<<"2.3.2">>},0},
+   {<<"riak_dt">>,
+!   {git,"git://github.com/basho/riak_dt.git",
+         {ref,"f7981d4ad7407ddc085f133f204dd71bf9d50c56"}},
+    0},
+   {<<"riak_sysmon">>,{pkg,<<"riak_sysmon">>,<<"2.1.2">>},0},
+   {<<"sext">>,{pkg,<<"sext">>,<<"1.5.0">>},0},
+   {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},1},
+   {<<"swc">>,
+!   {git,"git://github.com/vernemq/ServerWideClocks.git",
+         {ref,"4835239dca5a5f4ac7202dd94d7effcaa617d575"}},
+    0},
+   {<<"syslog">>,
+!   {git,"git://github.com/Vagabond/erlang-syslog",
+         {ref,"e24c9ee8f7bb3f066ec152c210af10c2c712759a"}},
+    1},
+   {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},2},
+   {<<"vernemq_dev">>,
+!   {git,"git://github.com/vernemq/vernemq_dev.git",
+         {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
+    0}]}.
+  [
+--- 48,100 ----
+   {<<"jsx">>,{pkg,<<"jsx">>,<<"2.10.0">>},0},
+   {<<"lager">>,{pkg,<<"lager">>,<<"3.8.0">>},0},
+   {<<"lager_syslog">>,
+!   {git,"https://github.com/basho/lager_syslog.git",
+         {ref,"126dd0284fcac9b01613189a82facf8d803411a2"}},
+    0},
+   {<<"luerl">>,
+!   {git,"https://github.com/rvirding/luerl.git",
+         {ref,"795192ccd812d14578b6bf3331ed8e67a6c8bf0b"}},
+    0},
+   {<<"mcd">>,
+!   {git,"https://github.com/EchoTeam/mcd.git",
+         {ref,"b5b4a32ef2c9e2f6a4faa992536cb3da3548e0f8"}},
+    0},
+   {<<"metrics">>,{pkg,<<"metrics">>,<<"1.0.1">>},1},
+   {<<"mimerl">>,{pkg,<<"mimerl">>,<<"1.2.0">>},1},
+   {<<"mongodb">>,
+!   {git,"https://github.com/comtihon/mongodb-erlang.git",
+         {ref,"9b53c4dcd931c48c5474dcdb8825e4b0afa2bff5"}},
+    0},
+   {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},2},
+   {<<"pbkdf2">>,
+!   {git,"https://github.com/comtihon/erlang-pbkdf2.git",
+         {ref,"7076584f5377e98600a7e2cb81980b2992fb2f71"}},
+    1},
+   {<<"plumtree">>,
+!   {git,"https://github.com/vernemq/plumtree.git",
+         {ref,"11cf17930e8acf29f9cdc90ae4796c9ceb7885eb"}},
+    0},
+   {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0},
+   {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},0},
+   {<<"recon">>,{pkg,<<"recon">>,<<"2.3.2">>},0},
+   {<<"riak_dt">>,
+!   {git,"https://github.com/basho/riak_dt.git",
+         {ref,"f7981d4ad7407ddc085f133f204dd71bf9d50c56"}},
+    0},
+   {<<"riak_sysmon">>,{pkg,<<"riak_sysmon">>,<<"2.1.2">>},0},
+   {<<"sext">>,{pkg,<<"sext">>,<<"1.5.0">>},0},
+   {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.5">>},1},
+   {<<"swc">>,
+!   {git,"https://github.com/vernemq/ServerWideClocks.git",
+         {ref,"4835239dca5a5f4ac7202dd94d7effcaa617d575"}},
+    0},
+   {<<"syslog">>,
+!   {git,"https://github.com/Vagabond/erlang-syslog",
+         {ref,"e24c9ee8f7bb3f066ec152c210af10c2c712759a"}},
+    1},
+   {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},2},
+   {<<"vernemq_dev">>,
+!   {git,"https://github.com/vernemq/vernemq_dev.git",
+         {ref,"741655f532ad16bb501d01230c7fb68dbae523d2"}},
+    0}]}.
+  [


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
It's not able to build vernemq image because it makes use of deprecated git protocol.


* **What is the new behavior (if this is a feature change)?**
Now, it's possible to build vernemq image because it's using https instead of git protocol.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
