### PR TITLE
Corrige quebra na leitura de string pelo retriever

### DIFF
--- a/storage/time-series/influxdb/retriever/app/influx/DeviceDataRepository.js
+++ b/storage/time-series/influxdb/retriever/app/influx/DeviceDataRepository.js
@@ -30,7 +30,6 @@ class DeviceDataRepository {
    * @param {String} defaultBucket  Bucket Name for all data write
    * @param {@influxdata/influxdb-client/InfluxDB} influxDBConnection  Request timeout in
    *  the communication with the influxdb
-   * @param {Boolean} readAsString Indicates whether to read Influxdb data as a String
    *
    */
   constructor(defaultBucket, influxDBConnection, logger) {
@@ -262,7 +261,6 @@ class DeviceDataRepository {
       this.logger.debug(`queryByField: fluxQuery=${fluxQuery}`);
 
       const queryApi = this.influxDB.getQueryApi({ org, gzip: false });
-      const { readAsString } = this;
 
       const loggerOuter = this.logger;
 
@@ -272,17 +270,10 @@ class DeviceDataRepository {
           next(row, tableMeta) {
             const o = tableMeta.toObject(row);
             loggerOuter.debug(`queryByField: queryRows.next=${JSON.stringify(o, null, 2)}`);
-            let validatedValue;
-            if (readAsString) {
-              validatedValue = JSON.parse(o._value);
-            } else {
-              validatedValue = o._value;
-            }
-            // when storer write the data it just check if is a number or a boolean
-            // the others types are writer as string with json stringify
+
             result.push({
               ts: o._time,
-              value: validatedValue,
+              value: o._value,
             });
           },
           error(error) {

--- a/storage/time-series/influxdb/retriever/config/default.conf
+++ b/storage/time-series/influxdb/retriever/config/default.conf
@@ -35,7 +35,6 @@ influx.max.timeout.ms:integer=30000
 influx.heathcheck.ms:integer=30000
 influx.default.token:string=dojot@token_default
 influx.default.bucket:string=devices
-influx.default.read.as.string:boolean=true
 
 #graphql configuration
 graphql.graphiql:boolean=${GRAPHIQL_EDITOR:-false}


### PR DESCRIPTION
Quando o telegraf salva uma string no influxDB, ele a mantém como string "simples", tendo apenas um par de aspas

![image](https://user-images.githubusercontent.com/111523628/204387453-64df19d9-e2da-4e55-8a8b-a046e7e89531.png)

Em contraste com a forma que o storer armazenava: escapando aspas dentro da string, conforme print

![image](https://user-images.githubusercontent.com/111523628/204387683-836c5258-1593-4fde-b8fe-d9b1e22440be.png)

Por conta disso, ao tentar fazer um JSON.parse da string nova, o retriever quebrava.

Foi retirado o código desse parsing, que no cenário atual não é mais necessário